### PR TITLE
tightening the conversion operators on level 3

### DIFF
--- a/include/cnl/bits/fixed_point_type.h
+++ b/include/cnl/bits/fixed_point_type.h
@@ -165,16 +165,9 @@ namespace cnl {
             return *this;
         }
 
-        /// returns value represented as bool
-        template<typename R = Rep>
-        constexpr operator typename std::enable_if<std::is_convertible<Rep, bool>::value, bool>() const
-        {
-            return static_cast<bool>(_base::data());
-        }
-
         /// returns value represented as integral
         template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_integer, int> Dummy = 0>
-        constexpr operator S() const
+        explicit constexpr operator S() const
         {
             return rep_to_integral<S>(_base::data());
         }


### PR DESCRIPTION
- no need for fixed_point::operator bool()
  - already seems to be a perfectly good one in base class
- fixed_point::operator Integer() made explicit
  - otherwise if participates in operator overload resolution