### PR TITLE
adds cnl::numeric_limits

### DIFF
--- a/include/cnl/auxiliary/elastic_fixed_point.h
+++ b/include/cnl/auxiliary/elastic_fixed_point.h
@@ -77,7 +77,7 @@ namespace cnl {
 
     /// \brief generate an \ref cnl::elastic_fixed_point object of given value
     template<class Narrowest = int, class Integral = int>
-    constexpr elastic_fixed_point<std::numeric_limits<Integral>::digits, 0, Narrowest>
+    constexpr elastic_fixed_point<numeric_limits<Integral>::digits, 0, Narrowest>
     make_elastic_fixed_point(Integral value)
     {
         return {value};

--- a/include/cnl/bits/fixed_point_arithmetic.h
+++ b/include/cnl/bits/fixed_point_arithmetic.h
@@ -58,14 +58,14 @@ namespace cnl {
                 template<class LhsRep, int LhsExponent, class Rhs>
                 struct binary_pair<fixed_point<LhsRep, LhsExponent>, Rhs>
                         : binary_pair_base<LhsRep, LhsExponent, Rhs, 0> {
-                    static_assert(std::numeric_limits<Rhs>::is_integer,
+                    static_assert(numeric_limits<Rhs>::is_integer,
                             "named arithmetic functions take only fixed_point and integral types");
                 };
 
                 template<class Lhs, class RhsRep, int RhsExponent>
                 struct binary_pair<Lhs, fixed_point<RhsRep, RhsExponent>>
                         : binary_pair_base<Lhs, 0, RhsRep, RhsExponent> {
-                    static_assert(std::numeric_limits<Lhs>::is_integer,
+                    static_assert(numeric_limits<Lhs>::is_integer,
                             "named arithmetic functions take only fixed_point and integral types");
                 };
 
@@ -156,7 +156,7 @@ namespace cnl {
 
                     static constexpr int digits = cnl::digits<Lhs>::value+cnl::digits<Rhs>::value;
                     static constexpr bool is_signed =
-                            std::numeric_limits<lhs_rep>::is_signed || std::numeric_limits<rhs_rep>::is_signed;
+                            numeric_limits<lhs_rep>::is_signed || numeric_limits<rhs_rep>::is_signed;
 
                     using prewidened_result_rep = _impl::make_signed_t<rep_op_result, is_signed>;
                     using rep_type = set_digits_t<prewidened_result_rep, digits>;
@@ -176,7 +176,7 @@ namespace cnl {
                     static constexpr int fractional_digits = _impl::fractional_digits<Lhs>::value+_impl::integer_digits<Rhs>::value;
                     static constexpr int necessary_digits = integer_digits+fractional_digits;
                     static constexpr bool is_signed =
-                            std::numeric_limits<lhs_rep>::is_signed || std::numeric_limits<rhs_rep>::is_signed;
+                            numeric_limits<lhs_rep>::is_signed || numeric_limits<rhs_rep>::is_signed;
 
                     static constexpr int promotion_digits = digits<rep_op_result>::value;
                     static constexpr int digits = _impl::max(necessary_digits, promotion_digits);

--- a/include/cnl/bits/fixed_point_common_type.h
+++ b/include/cnl/bits/fixed_point_common_type.h
@@ -32,7 +32,7 @@ namespace cnl {
                 // generates a fixed-point type that is as big as both of them (or as close as possible)
                 template<class LhsRep, int LhsExponent, class RhsInteger>
                 struct common_type_mixed<fixed_point
-                        <LhsRep, LhsExponent>, RhsInteger, _impl::enable_if_t<std::numeric_limits<RhsInteger>::is_integer>> : std::common_type<
+                        <LhsRep, LhsExponent>, RhsInteger, _impl::enable_if_t<numeric_limits<RhsInteger>::is_integer>> : std::common_type<
                         fixed_point<LhsRep, LhsExponent>, fixed_point<RhsInteger, 0>> {
                 };
 

--- a/include/cnl/bits/fixed_point_extras.h
+++ b/include/cnl/bits/fixed_point_extras.h
@@ -184,7 +184,7 @@ namespace std {
     // and some are undefined
     template<class Rep, int Exponent>
     struct numeric_limits<cnl::fixed_point<Rep, Exponent>>
-            : std::numeric_limits<cnl::_impl::number_base<cnl::fixed_point<Rep, Exponent>, Rep>> {
+            : numeric_limits<cnl::_impl::number_base<cnl::fixed_point<Rep, Exponent>, Rep>> {
         // fixed-point-specific helpers
         using _value_type = cnl::fixed_point<Rep, Exponent>;
         using _rep = typename _value_type::rep;

--- a/include/cnl/bits/fixed_point_operators.h
+++ b/include/cnl/bits/fixed_point_operators.h
@@ -111,7 +111,7 @@ namespace cnl {
     template<
             class LhsRep, int LhsExponent,
             class RhsInteger,
-            typename = _impl::enable_if_t<std::numeric_limits<RhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<RhsInteger>::is_integer>>
     constexpr auto operator+(fixed_point<LhsRep, LhsExponent> const& lhs, RhsInteger const& rhs)
     -> decltype(lhs + fixed_point<RhsInteger, 0>{rhs})
     {
@@ -121,7 +121,7 @@ namespace cnl {
     template<
             class LhsRep, int LhsExponent,
             class RhsInteger,
-            typename = _impl::enable_if_t<std::numeric_limits<RhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<RhsInteger>::is_integer>>
     constexpr auto operator-(fixed_point<LhsRep, LhsExponent> const& lhs, RhsInteger const& rhs)
     -> decltype(lhs - fixed_point<RhsInteger, 0>{rhs})
     {
@@ -131,7 +131,7 @@ namespace cnl {
     template<
             class LhsRep, int LhsExponent,
             class RhsInteger,
-            typename = _impl::enable_if_t<std::numeric_limits<RhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<RhsInteger>::is_integer>>
     constexpr auto operator*(fixed_point<LhsRep, LhsExponent> const& lhs, RhsInteger const& rhs)
     -> decltype(lhs*fixed_point<RhsInteger>(rhs))
     {
@@ -141,7 +141,7 @@ namespace cnl {
     template<
             class LhsRep, int LhsExponent,
             class RhsInteger,
-            typename = _impl::enable_if_t<std::numeric_limits<RhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<RhsInteger>::is_integer>>
     constexpr auto operator/(fixed_point<LhsRep, LhsExponent> const& lhs, RhsInteger const& rhs)
     -> decltype(lhs/fixed_point<RhsInteger>{rhs})
     {
@@ -152,7 +152,7 @@ namespace cnl {
     template<
             class LhsInteger,
             class RhsRep, int RhsExponent,
-            typename = _impl::enable_if_t<std::numeric_limits<LhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<LhsInteger>::is_integer>>
     constexpr auto operator+(LhsInteger const& lhs, fixed_point<RhsRep, RhsExponent> const& rhs)
     -> decltype(fixed_point<LhsInteger, 0>{lhs} + rhs)
     {
@@ -162,7 +162,7 @@ namespace cnl {
     template<
             class LhsInteger,
             class RhsRep, int RhsExponent,
-            typename = _impl::enable_if_t<std::numeric_limits<LhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<LhsInteger>::is_integer>>
     constexpr auto operator-(LhsInteger const& lhs, fixed_point<RhsRep, RhsExponent> const& rhs)
     -> decltype(fixed_point<LhsInteger>{lhs}-rhs)
     {
@@ -172,7 +172,7 @@ namespace cnl {
     template<
             class LhsInteger,
             class RhsRep, int RhsExponent,
-            typename = _impl::enable_if_t<std::numeric_limits<LhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<LhsInteger>::is_integer>>
     constexpr auto operator*(LhsInteger const& lhs, fixed_point<RhsRep, RhsExponent> const& rhs)
     -> decltype(fixed_point<LhsInteger>{lhs}*rhs)
     {
@@ -182,7 +182,7 @@ namespace cnl {
     template<
             class LhsInteger,
             class RhsRep, int RhsExponent,
-            typename = _impl::enable_if_t<std::numeric_limits<LhsInteger>::is_integer>>
+            typename = _impl::enable_if_t<numeric_limits<LhsInteger>::is_integer>>
     constexpr auto operator/(LhsInteger const& lhs, fixed_point<RhsRep, RhsExponent> const& rhs)
     -> decltype(fixed_point<LhsInteger>{lhs}/rhs)
     {

--- a/include/cnl/bits/fixed_point_type.h
+++ b/include/cnl/bits/fixed_point_type.h
@@ -110,28 +110,28 @@ namespace cnl {
         }
 
         /// constructor taking an integer type
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_integer, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy = 0>
         constexpr fixed_point(S const& s)
             : fixed_point(fixed_point<S, 0>::from_data(s))
         {
         }
 
         /// constructor taking a floating-point type
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_iec559, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_iec559, int> Dummy = 0>
         constexpr fixed_point(S s)
                 :_base(floating_point_to_rep(s))
         {
         }
 
         /// copy assignment operator taking an integer type
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_integer, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy = 0>
         CNL_COPY_CONSTEXPR fixed_point& operator=(S s)
         {
             return operator=(fixed_point<S, 0>::from_data(s));
         }
 
         /// copy assignment operator taking a floating-point type
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_iec559, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_iec559, int> Dummy = 0>
         CNL_COPY_CONSTEXPR fixed_point& operator=(S s)
         {
             _base::operator=(floating_point_to_rep(s));
@@ -147,14 +147,14 @@ namespace cnl {
         }
 
         /// returns value represented as integral
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_integer, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy = 0>
         explicit constexpr operator S() const
         {
             return rep_to_integral<S>(_base::data());
         }
 
         /// returns value represented as floating-point
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_iec559, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_iec559, int> Dummy = 0>
         explicit constexpr operator S() const
         {
             return rep_to_floating_point<S>(_base::data());
@@ -167,10 +167,10 @@ namespace cnl {
         }
 
     private:
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_iec559, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_iec559, int> Dummy = 0>
         static constexpr S one();
 
-        template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_integer, int> Dummy = 0>
+        template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy = 0>
         static constexpr S one();
 
         template<class S>
@@ -235,7 +235,7 @@ namespace cnl {
                     digits<Input>::value<=digits<Output>::value,
                     Output, Input>::type;
 
-            return (exp>-std::numeric_limits<larger>::digits)
+            return (exp>-numeric_limits<larger>::digits)
                    ? static_cast<Output>(_impl::scale<larger>(static_cast<larger>(i), 2, exp))
                    : Output{0};
         }
@@ -252,7 +252,7 @@ namespace cnl {
                 template<class S, int Exponent, enable_if_t<Exponent==0, int> Dummy = 0>
                 constexpr S pow2()
                 {
-                    static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+                    static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
                     return S{1.};
                 }
 
@@ -260,14 +260,14 @@ namespace cnl {
                         enable_if_t<!(Exponent<=0) && (Exponent<8), int> Dummy = 0>
                 constexpr S pow2()
                 {
-                    static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+                    static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
                     return pow2<S, Exponent-1>()*S(2);
                 }
 
                 template<class S, int Exponent, enable_if_t<(Exponent>=8), int> Dummy = 0>
                 constexpr S pow2()
                 {
-                    static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+                    static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
                     return pow2<S, Exponent-8>()*S(256);
                 }
 
@@ -275,14 +275,14 @@ namespace cnl {
                         enable_if_t<!(Exponent>=0) && (Exponent>-8), int> Dummy = 0>
                 constexpr S pow2()
                 {
-                    static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+                    static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
                     return pow2<S, Exponent+1>()*S(.5);
                 }
 
                 template<class S, int Exponent, enable_if_t<(Exponent<=-8), int> Dummy = 0>
                 constexpr S pow2()
                 {
-                    static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+                    static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
                     return pow2<S, Exponent+8>()*S(.003906250);
                 }
             }
@@ -293,14 +293,14 @@ namespace cnl {
     // cnl::fixed_point<> member definitions
 
     template<class Rep, int Exponent>
-    template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_iec559, int> Dummy>
+    template<class S, _impl::enable_if_t<numeric_limits<S>::is_iec559, int> Dummy>
     constexpr S fixed_point<Rep, Exponent>::one()
     {
         return _impl::fp::type::pow2<S, -exponent>();
     }
 
     template<class Rep, int Exponent>
-    template<class S, _impl::enable_if_t<std::numeric_limits<S>::is_integer, int> Dummy>
+    template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy>
     constexpr S fixed_point<Rep, Exponent>::one()
     {
         return fixed_point<S, 0>::from_data(1);
@@ -310,7 +310,7 @@ namespace cnl {
     template<class S>
     constexpr S fixed_point<Rep, Exponent>::inverse_one()
     {
-        static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+        static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
         return _impl::fp::type::pow2<S, exponent>();
     }
 
@@ -318,7 +318,7 @@ namespace cnl {
     template<class S>
     constexpr S fixed_point<Rep, Exponent>::rep_to_integral(rep r)
     {
-        static_assert(std::numeric_limits<S>::is_integer, "S must be integral type");
+        static_assert(numeric_limits<S>::is_integer, "S must be integral type");
 
         return _impl::shift_left<exponent, S>(r);
     }
@@ -327,7 +327,7 @@ namespace cnl {
     template<class S>
     constexpr typename fixed_point<Rep, Exponent>::rep fixed_point<Rep, Exponent>::floating_point_to_rep(S s)
     {
-        static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+        static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
         return static_cast<rep>(s*one<S>());
     }
 
@@ -335,7 +335,7 @@ namespace cnl {
     template<class S>
     constexpr S fixed_point<Rep, Exponent>::rep_to_floating_point(rep r)
     {
-        static_assert(std::numeric_limits<S>::is_iec559, "S must be floating-point type");
+        static_assert(numeric_limits<S>::is_iec559, "S must be floating-point type");
         return S(r)*inverse_one<S>();
     }
 

--- a/include/cnl/bits/limits.h
+++ b/include/cnl/bits/limits.h
@@ -5,7 +5,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 /// \file
-/// \brief specialization of `std::numeric_limits` for 128-bit integer types
+/// \brief specialization of `numeric_limits` for 128-bit integer types
 
 #if !defined(CNL_LIMITS_H)
 #define CNL_LIMITS_H 1
@@ -16,25 +16,13 @@
 #include <cstdint>
 #include <limits>
 
-#if defined(CNL_NUMERIC_LIMITS_128_PROVIDED)
-#error CNL_NUMERIC_LIMITS_128_PROVIDED already defined
-#endif
+namespace cnl {
 
-// CNL_NUMERIC_LIMITS_128_PROVIDED defined if
-// standard library specializes std::numeric_limits for 128-bit integer
-#if defined(__clang__)
-#if (__clang_major__ >= 4)
-#define CNL_NUMERIC_LIMITS_128_PROVIDED
-#endif
-#elif defined(__GNUG__)
-#if (__cplusplus <= 201402L)
-#define CNL_NUMERIC_LIMITS_128_PROVIDED
-#endif
-#endif
+    template<class T>
+    struct numeric_limits : std::numeric_limits<T> {};
 
-#if defined(CNL_INT128_ENABLED) && !defined(CNL_NUMERIC_LIMITS_128_PROVIDED)
+#if defined(CNL_INT128_ENABLED)
 
-namespace std {
     template<>
     struct numeric_limits<CNL_INT128> : numeric_limits<long long> {
         static int const digits = CHAR_BIT*sizeof(CNL_INT128)-1;
@@ -88,8 +76,8 @@ namespace std {
             return min();
         }
     };
-}
 
 #endif  // CNL_INT128_ENABLED
+}
 
 #endif  // CNL_LIMITS_H

--- a/include/cnl/bits/number_base.h
+++ b/include/cnl/bits/number_base.h
@@ -19,7 +19,7 @@ namespace cnl {
         template<class Derived, class Rep>
         class number_base {
         public:
-            static_assert(std::numeric_limits<Rep>::is_integer, "number_base must be specialized with integer Rep type template parameter");
+            static_assert(numeric_limits<Rep>::is_integer, "number_base must be specialized with integer Rep type template parameter");
 
             using rep = Rep;
             using _derived = Derived;

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -118,7 +118,7 @@ namespace cnl {
         }
 
         /// construct from numeric type
-        template<class Number, _impl::enable_if_t<std::numeric_limits<Number>::is_specialized, int> Dummy = 0>
+        template<class Number, _impl::enable_if_t<numeric_limits<Number>::is_specialized, int> Dummy = 0>
         constexpr elastic_integer(Number n)
                 : _base(static_cast<rep>(n))
         {
@@ -177,9 +177,9 @@ namespace cnl {
 
     template<class Narrowest = int, class Integral, _impl::enable_if_t<!_impl::is_integral_constant<Integral>::value, int> Dummy = 0>
     constexpr auto make_elastic_integer(Integral const& value)
-    -> decltype(elastic_integer<std::numeric_limits<Integral>::digits, Narrowest>{value})
+    -> decltype(elastic_integer<numeric_limits<Integral>::digits, Narrowest>{value})
     {
-        return elastic_integer<std::numeric_limits<Integral>::digits, Narrowest>{value};
+        return elastic_integer<numeric_limits<Integral>::digits, Narrowest>{value};
     }
 
     namespace _elastic_integer_impl {
@@ -220,7 +220,7 @@ namespace cnl {
         return elastic_integer::from_data(
             static_cast<rep>(
                 rhs.data()
-                ^ ((static_cast<rep>(~0)) >> (std::numeric_limits<rep>::digits - RhsDigits))));
+                ^ ((static_cast<rep>(~0)) >> (numeric_limits<rep>::digits - RhsDigits))));
     }
 
     // operator<<
@@ -356,8 +356,8 @@ namespace cnl {
         struct operate_params {
             using lhs = elastic_integer<LhsDigits, LhsNarrowest>;
             using rhs = elastic_integer<RhsDigits, RhsNarrowest>;
-            using lhs_traits = std::numeric_limits<lhs>;
-            using rhs_traits = std::numeric_limits<rhs>;
+            using lhs_traits = numeric_limits<lhs>;
+            using rhs_traits = numeric_limits<rhs>;
 
             using policy = typename _impl::policy<OperationTag, lhs_traits, rhs_traits>;
 
@@ -424,22 +424,22 @@ namespace std {
 
     template<int LhsDigits, class LhsNarrowest, class Rhs>
     struct common_type<cnl::elastic_integer<LhsDigits, LhsNarrowest>, Rhs>
-            : common_type<cnl::elastic_integer<LhsDigits, LhsNarrowest>, cnl::elastic_integer<std::numeric_limits<Rhs>::digits, Rhs>> {
+            : common_type<cnl::elastic_integer<LhsDigits, LhsNarrowest>, cnl::elastic_integer<numeric_limits<Rhs>::digits, Rhs>> {
     };
 
     template<class Lhs, int RhsDigits, class RhsNarrowest>
     struct common_type<Lhs, cnl::elastic_integer<RhsDigits, RhsNarrowest>>
-            : common_type<cnl::elastic_integer<std::numeric_limits<Lhs>::digits, Lhs>, cnl::elastic_integer<RhsDigits, RhsNarrowest>> {
+            : common_type<cnl::elastic_integer<numeric_limits<Lhs>::digits, Lhs>, cnl::elastic_integer<RhsDigits, RhsNarrowest>> {
     };
 
     ////////////////////////////////////////////////////////////////////////////////
-    // std::numeric_limits for cnl::elastic_integer
+    // cnl::numeric_limits for cnl::elastic_integer
 
     namespace _elastic_integer_impl {
         ////////////////////////////////////////////////////////////////////////////////
         // cnl::_elastic_integer_impl::lowest
 
-        // helper for std::numeric_limits<cnl::elastic_integer<>>::lowest()
+        // cnl::helper for numeric_limits<cnl::elastic_integer<>>::lowest()
         template<class Rep, bool IsSigned>
         struct lowest;
 

--- a/include/cnl/num_traits.h
+++ b/include/cnl/num_traits.h
@@ -56,13 +56,13 @@ namespace cnl {
 
         template<_digits_type MinNumDigits, class Smaller, class T>
         struct enable_for_range
-                : std::enable_if<MinNumDigits <= std::numeric_limits<T>::digits &&
-                                 std::numeric_limits<Smaller>::digits < MinNumDigits> {
+                : std::enable_if<MinNumDigits <= numeric_limits<T>::digits &&
+                                 numeric_limits<Smaller>::digits < MinNumDigits> {
         };
 
         template<_digits_type MinNumDigits, class Smallest>
         struct enable_for_range<MinNumDigits, void, Smallest>
-                : std::enable_if<MinNumDigits <= std::numeric_limits<Smallest>::digits> {
+                : std::enable_if<MinNumDigits <= numeric_limits<Smallest>::digits> {
         };
 
         template<_digits_type MinNumDigits, class Smaller, class T>
@@ -139,7 +139,7 @@ namespace cnl {
 
         template<class Integer, _digits_type MinNumDigits>
         using set_digits_integer = typename std::conditional<
-                std::numeric_limits<Integer>::is_signed,
+                numeric_limits<Integer>::is_signed,
                 set_digits_signed<MinNumDigits>,
                 set_digits_unsigned<MinNumDigits>>::type;
     }
@@ -148,8 +148,8 @@ namespace cnl {
     // digits
 
     template<class T, class Enable = void>
-    struct digits : std::integral_constant<_digits_type, std::numeric_limits<T>::digits> {
-        static_assert(std::numeric_limits<T>::is_specialized, "cnl::digits is not correctly specialized for T");
+    struct digits : std::integral_constant<_digits_type, numeric_limits<T>::digits> {
+        static_assert(numeric_limits<T>::is_specialized, "cnl::digits is not correctly specialized for T");
     };
 
 #if (__cplusplus > 201402L)
@@ -187,7 +187,7 @@ namespace cnl {
     // cnl::is_unsigned
 
     template<class T>
-    struct is_signed : std::integral_constant<bool, std::numeric_limits<T>::is_signed> {
+    struct is_signed : std::integral_constant<bool, numeric_limits<T>::is_signed> {
     };
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -260,7 +260,7 @@ namespace cnl {
 
         template<class T1, class T2>
         struct common_signedness {
-            static constexpr bool _are_signed = std::numeric_limits<T1>::is_signed | std::numeric_limits<T2>::is_signed;
+            static constexpr bool _are_signed = numeric_limits<T1>::is_signed | numeric_limits<T2>::is_signed;
 
             using type = typename std::common_type<make_signed_t<T1, _are_signed>,
                     make_signed_t<T2, _are_signed>>::type;
@@ -276,12 +276,12 @@ namespace cnl {
         struct unsigned_or_float;
 
         template<class T>
-        struct unsigned_or_float<T, enable_if_t<std::numeric_limits<T>::is_iec559>> {
+        struct unsigned_or_float<T, enable_if_t<numeric_limits<T>::is_iec559>> {
             using type = T;
         };
 
         template<class T>
-        struct unsigned_or_float<T, enable_if_t<!std::numeric_limits<T>::is_iec559>> : make_unsigned<T> {
+        struct unsigned_or_float<T, enable_if_t<!numeric_limits<T>::is_iec559>> : make_unsigned<T> {
         };
 
         template<class T>
@@ -292,21 +292,21 @@ namespace cnl {
 
         template<class Encompasser, class Encompassed>
         struct encompasses_lower<Encompasser, Encompassed,
-                enable_if_t<std::numeric_limits<Encompasser>::is_signed
-                            && std::numeric_limits<Encompassed>::is_signed>> {
-            static constexpr bool value = std::numeric_limits<Encompasser>::lowest()
-                                          <= std::numeric_limits<Encompassed>::lowest();
+                enable_if_t<numeric_limits<Encompasser>::is_signed
+                            && numeric_limits<Encompassed>::is_signed>> {
+            static constexpr bool value = numeric_limits<Encompasser>::lowest()
+                                          <= numeric_limits<Encompassed>::lowest();
         };
 
         template<class Encompasser, class Encompassed>
         struct encompasses_lower<Encompasser, Encompassed,
-                enable_if_t<!std::numeric_limits<Encompassed>::is_signed>> : std::true_type {
+                enable_if_t<!numeric_limits<Encompassed>::is_signed>> : std::true_type {
         };
 
         template<class Encompasser, class Encompassed>
         struct encompasses_lower<Encompasser, Encompassed,
-                enable_if_t<!std::numeric_limits<Encompasser>::is_signed
-                            && std::numeric_limits<Encompassed>::is_signed>> : std::false_type {
+                enable_if_t<!numeric_limits<Encompasser>::is_signed
+                            && numeric_limits<Encompassed>::is_signed>> : std::false_type {
         };
 
         // true if Encompassed can be cast to Encompasser without chance of overflow
@@ -314,8 +314,8 @@ namespace cnl {
         struct encompasses {
             static constexpr bool _lower = encompasses_lower<Encompasser, Encompassed>::value;
             static constexpr bool _upper =
-                    static_cast<unsigned_or_float_t<Encompasser>>(std::numeric_limits<Encompasser>::max())
-                    >= static_cast<unsigned_or_float_t<Encompassed>>(std::numeric_limits<Encompassed>::max());
+                    static_cast<unsigned_or_float_t<Encompasser>>(numeric_limits<Encompasser>::max())
+                    >= static_cast<unsigned_or_float_t<Encompassed>>(numeric_limits<Encompassed>::max());
 
             static constexpr bool value = _lower && _upper;
         };
@@ -326,7 +326,7 @@ namespace cnl {
         template<class T>
         struct is_integer_or_float : std::integral_constant<
                 bool,
-                std::numeric_limits<T>::is_integer || std::numeric_limits<T>::is_iec559> {
+                numeric_limits<T>::is_integer || numeric_limits<T>::is_iec559> {
         };
     }
 

--- a/include/cnl/numeric.h
+++ b/include/cnl/numeric.h
@@ -40,7 +40,7 @@ namespace cnl {
         };
 
         template<class Integer>
-        struct trailing_bits<Integer, _impl::enable_if_t<std::numeric_limits<Integer>::is_signed>> {
+        struct trailing_bits<Integer, _impl::enable_if_t<numeric_limits<Integer>::is_signed>> {
             static constexpr int f(Integer value)
             {
                 // Most negative number is not exploited;
@@ -101,12 +101,12 @@ namespace cnl {
     namespace _numeric_impl {
         struct used_bits {
             template<class Integer>
-            constexpr _impl::enable_if_t<!std::numeric_limits<Integer>::is_signed, int> operator()(Integer value) const
+            constexpr _impl::enable_if_t<!numeric_limits<Integer>::is_signed, int> operator()(Integer value) const
             {
                 return value ? used_bits_positive(value) : 0;
             }
 
-            template<class Integer, class = _impl::enable_if_t<std::numeric_limits<Integer>::is_signed, int>>
+            template<class Integer, class = _impl::enable_if_t<numeric_limits<Integer>::is_signed, int>>
             constexpr int operator()(Integer value) const
             {
                 // Most negative number is not exploited;

--- a/include/cnl/overflow.h
+++ b/include/cnl/overflow.h
@@ -79,12 +79,12 @@ namespace cnl {
 
         // positive_digits
         template<class T>
-        struct positive_digits : public std::integral_constant<int, std::numeric_limits<T>::digits> {
+        struct positive_digits : public std::integral_constant<int, numeric_limits<T>::digits> {
         };
 
         template<class T>
         struct negative_digits
-                : public std::integral_constant<int, std::is_signed<T>::value ? std::numeric_limits<T>::digits : 0> {
+                : public std::integral_constant<int, std::is_signed<T>::value ? numeric_limits<T>::digits : 0> {
         };
 
         // is_positive_overflow
@@ -103,7 +103,7 @@ namespace cnl {
                 _impl::enable_if_t<(positive_digits<Destination>::value<positive_digits<Source>::value), int> dummy = 0>
         constexpr bool is_positive_overflow(Source const& source)
         {
-            return source>static_cast<Source>(std::numeric_limits<Destination>::max());
+            return source>static_cast<Source>(numeric_limits<Destination>::max());
         }
 
         // is_negative_overflow
@@ -122,7 +122,7 @@ namespace cnl {
                 _impl::enable_if_t<(negative_digits<Destination>::value<negative_digits<Source>::value), int> dummy = 0>
         constexpr bool is_negative_overflow(Source const& source)
         {
-            return source<static_cast<Source>(std::numeric_limits<Destination>::lowest());
+            return source<static_cast<Source>(numeric_limits<Destination>::lowest());
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -155,7 +155,7 @@ namespace cnl {
     template<class Result, class Input>
     constexpr Result convert(saturated_overflow_tag, Input const& rhs)
     {
-        using numeric_limits = std::numeric_limits<Result>;
+        using numeric_limits = numeric_limits<Result>;
         return !_impl::encompasses<Result, Input>::value
                ? _overflow_impl::is_positive_overflow<Result>(rhs)
                  ? numeric_limits::max()
@@ -187,7 +187,7 @@ namespace cnl {
             -> decltype(lhs+rhs)
             {
                 using result_type = decltype(lhs+rhs);
-                using numeric_limits = std::numeric_limits<result_type>;
+                using numeric_limits = numeric_limits<result_type>;
                 return _overflow_impl::return_if(
                         !((rhs>=_impl::from_rep<Rhs>(0))
                           ? (lhs>numeric_limits::max()-rhs)
@@ -204,7 +204,7 @@ namespace cnl {
             -> _impl::op_result<_impl::add_op, Lhs, Rhs>
             {
                 using result_type = decltype(lhs+rhs);
-                using numeric_limits = std::numeric_limits<result_type>;
+                using numeric_limits = numeric_limits<result_type>;
                 return (rhs>0)
                        ? (lhs>numeric_limits::max()-rhs) ? numeric_limits::max() : lhs+rhs
                        : (lhs<numeric_limits::lowest()-rhs) ? numeric_limits::lowest() : lhs+rhs;
@@ -241,7 +241,7 @@ namespace cnl {
             -> decltype(lhs-rhs)
             {
                 using result_type = decltype(lhs-rhs);
-                using numeric_limits = std::numeric_limits<result_type>;
+                using numeric_limits = numeric_limits<result_type>;
                 return _overflow_impl::return_if(
                         (rhs<_impl::from_rep<Rhs>(0))
                         ? (lhs<=numeric_limits::max()+rhs)
@@ -258,7 +258,7 @@ namespace cnl {
             -> _impl::op_result<_impl::subtract_op, Lhs, Rhs>
             {
                 using result_type = decltype(lhs-rhs);
-                using numeric_limits = std::numeric_limits<result_type>;
+                using numeric_limits = numeric_limits<result_type>;
                 return (rhs<0)
                        ? (lhs>numeric_limits::max()+rhs) ? numeric_limits::max() : lhs-rhs
                        : (lhs<numeric_limits::lowest()+rhs) ? numeric_limits::lowest() : lhs-rhs;
@@ -291,7 +291,7 @@ namespace cnl {
         template<class Lhs, class Rhs>
         constexpr bool is_multiply_overflow(Lhs const& lhs, Rhs const& rhs)
         {
-            using result_nl = std::numeric_limits<decltype(lhs*rhs)>;
+            using result_nl = numeric_limits<decltype(lhs*rhs)>;
             return lhs && rhs && ((lhs>Lhs{})
                                   ? ((rhs>Rhs{}) ? (result_nl::max()/rhs) : (result_nl::lowest()/rhs))<lhs
                                   : ((rhs>Rhs{}) ? (result_nl::lowest()/rhs) : (result_nl::max()/rhs))>lhs);
@@ -318,8 +318,8 @@ namespace cnl {
                 using result_type = decltype(lhs*rhs);
                 return is_multiply_overflow(lhs, rhs)
                        ? ((lhs>0) ^ (rhs>0))
-                         ? std::numeric_limits<result_type>::lowest()
-                         : std::numeric_limits<result_type>::max()
+                         ? numeric_limits<result_type>::lowest()
+                         : numeric_limits<result_type>::max()
                        : lhs*rhs;
             }
         };

--- a/include/cnl/precise_integer.h
+++ b/include/cnl/precise_integer.h
@@ -28,11 +28,11 @@ namespace cnl {
 
         constexpr precise_integer() = default;
 
-        template<class T, _impl::enable_if_t<std::numeric_limits<T>::is_integer, int> Dummy = 0>
+        template<class T, _impl::enable_if_t<numeric_limits<T>::is_integer, int> Dummy = 0>
         constexpr precise_integer(T const& v)
                 : super(static_cast<Rep>(v)) { }
 
-        template<class T, _impl::enable_if_t<!std::numeric_limits<T>::is_integer, int> Dummy = 0>
+        template<class T, _impl::enable_if_t<!numeric_limits<T>::is_integer, int> Dummy = 0>
         constexpr precise_integer(T const& v)
                 : super(rounding::template convert<Rep>(v)) { }
 

--- a/include/cnl/safe_integer.h
+++ b/include/cnl/safe_integer.h
@@ -145,8 +145,8 @@ namespace cnl {
         constexpr safe_integer(std::integral_constant<Integral, Value>)
                 : _base(static_cast<rep>(Value))
         {
-            static_assert(Value <= std::numeric_limits<rep>::max(), "initialization by out-of-range value");
-            static_assert(!std::numeric_limits<Integral>::is_signed || Value >= std::numeric_limits<rep>::lowest(), "initialization by out-of-range value");
+            static_assert(Value <= numeric_limits<rep>::max(), "initialization by out-of-range value");
+            static_assert(!numeric_limits<Integral>::is_signed || Value >= numeric_limits<rep>::lowest(), "initialization by out-of-range value");
         }
 
         template<class T>

--- a/src/test/boost.simd.cpp
+++ b/src/test/boost.simd.cpp
@@ -51,11 +51,11 @@ namespace cnl {
 
 namespace {
     namespace test_numeric_limits {
-        static_assert(std::numeric_limits<pack<int>>::is_integer, "");
-        static_assert(!std::numeric_limits<pack<int>>::is_iec559, "");
+        static_assert(cnl::numeric_limits<pack<int>>::is_integer, "");
+        static_assert(!cnl::numeric_limits<pack<int>>::is_iec559, "");
 
-        static_assert(!std::numeric_limits<pack < float>>::is_integer, "");
-        static_assert(std::numeric_limits<pack < float>>::is_iec559, "");
+        static_assert(!cnl::numeric_limits<pack < float>>::is_integer, "");
+        static_assert(cnl::numeric_limits<pack < float>>::is_iec559, "");
     }
 
     namespace test_set_digits {

--- a/src/test/cppnow2017.cpp
+++ b/src/test/cppnow2017.cpp
@@ -61,20 +61,20 @@ namespace prototypes {
 
     using bad1 = bad_safe_integer<31, true>;
 
-    using bad2 = bad_safe_integer<numeric_limits<int>::digits, true>;
+    using bad2 = bad_safe_integer<cnl::numeric_limits<int>::digits, true>;
 }
 
 #if defined(CNL_EXCEPTIONS_ENABLED)
 TEST(cppnow2017, safe_integer_example)
 {
     // multiplication of safe_integer<int> cannot exceed numeric limits
-    EXPECT_THROW(safe_integer<int32_t>{numeric_limits<int32_t>::max()}*2, overflow_error);
+    EXPECT_THROW(safe_integer<int32_t>{cnl::numeric_limits<int32_t>::max()}*2, overflow_error);
 
     // difference from safe_integer<unsigned> cannot be negative
     EXPECT_THROW(safe_integer<unsigned>{0}-1, overflow_error);
 
     // conversion to safe_integer<char> cannot exceed numeric limits
-    EXPECT_THROW(safe_integer<short>{numeric_limits<double>::max()}, overflow_error);
+    EXPECT_THROW(safe_integer<short>{cnl::numeric_limits<double>::max()}, overflow_error);
 
     // value of safe_integer<int> cannot be indeterminate
     //auto d = safe_integer<int>{};  // compiler error? exception? zero-initialization?
@@ -97,7 +97,7 @@ namespace elastic_integer_example {
     // run-time overflow is not my concern
     constexpr auto d = elastic_integer<8, signed>{256};
     static_assert(identical(d, elastic_integer<8, signed>{256}), "error in CppNow 2017 slide");
-    static_assert(d>numeric_limits<decltype(d)>::max(), "error in CppNow 2017 slide");
+    static_assert(d>cnl::numeric_limits<decltype(d)>::max(), "error in CppNow 2017 slide");
 }
 
 namespace acme_ndebug {
@@ -210,8 +210,8 @@ namespace composite {
     {
         auto product = a.data()*b.data();
 
-        if (numeric_limits<Rep1>::digits+numeric_limits<Rep2>::digits
-                >numeric_limits<decltype(product)>::digits) {
+        if (cnl::numeric_limits<Rep1>::digits+cnl::numeric_limits<Rep2>::digits
+                >cnl::numeric_limits<decltype(product)>::digits) {
             // do some overflow checking
         }
 

--- a/src/test/elastic/elastic_integer.cpp
+++ b/src/test/elastic/elastic_integer.cpp
@@ -26,9 +26,9 @@ namespace {
         using cnl::from_value;
 
         static_assert(identical(cnl::from_value<elastic_integer<3>, int>::type{1},
-                                elastic_integer<std::numeric_limits<int>::digits>{1}), "elastic_integer test failed");
+                                elastic_integer<cnl::numeric_limits<int>::digits>{1}), "elastic_integer test failed");
         static_assert(identical(cnl::_impl::from_value<elastic_integer<3>>(1),
-                elastic_integer<std::numeric_limits<int>::digits>{1}), "elastic_integer test failed");
+                elastic_integer<cnl::numeric_limits<int>::digits>{1}), "elastic_integer test failed");
         static_assert(identical(cnl::_impl::from_value<elastic_integer<1>>(INT32_C(0)), elastic_integer<31>{0}), "cnl::elastic_integer test failed");
     }
 
@@ -47,11 +47,11 @@ namespace {
         static_assert(precedes<elastic_integer<1>, int32_t>::value, "");
         static_assert(!precedes<int32_t, elastic_integer<1>>::value, "");
         static_assert(
-                operate(elastic_integer<31>{0x7fffffff}, elastic_integer<31>{std::numeric_limits<std::int32_t>::min()}, cnl::_impl::greater_than_tag),
+                operate(elastic_integer<31>{0x7fffffff}, elastic_integer<31>{cnl::numeric_limits<std::int32_t>::min()}, cnl::_impl::greater_than_tag),
                 "cnl::elastic_integer test failed");
         static_assert(operate(
                 elastic_integer<31>{0x7fffffff},
-                elastic_integer<31>{std::numeric_limits<std::int32_t>::min()},
+                elastic_integer<31>{cnl::numeric_limits<std::int32_t>::min()},
                 cnl::_impl::greater_than_tag),
                       "cnl::elastic_integer test failed");
         static_assert(identical(
@@ -135,28 +135,28 @@ namespace {
         // unsigned{0}-unsigned{max}
         static_assert(
                 identical(
-                        elastic_integer<5, unsigned>{0}-std::numeric_limits<elastic_integer<5, unsigned>>::max(),
+                        elastic_integer<5, unsigned>{0}-cnl::numeric_limits<elastic_integer<5, unsigned>>::max(),
                         elastic_integer<5, signed>{-31}),
                 "cnl::elastic_integer test failed");
 
         // -signed{max}-unsigned{max}
         static_assert(
                 identical(
-                        -std::numeric_limits<elastic_integer<7>>::max()-std::numeric_limits<elastic_integer<4, unsigned>>::max(),
+                        -cnl::numeric_limits<elastic_integer<7>>::max()-cnl::numeric_limits<elastic_integer<4, unsigned>>::max(),
                         elastic_integer<8>{-142}),
                 "cnl::elastic_integer test failed");
 
         // unsigned{max}+signed{max}
         static_assert(
                 identical(
-                        std::numeric_limits<elastic_integer<15, unsigned>>::max()+std::numeric_limits<elastic_integer<19>>::max(),
+                        cnl::numeric_limits<elastic_integer<15, unsigned>>::max()+cnl::numeric_limits<elastic_integer<19>>::max(),
                         elastic_integer<20>{((1<<15)-1)+((1<<19)-1)}),
                 "cnl::elastic_integer test failed");
 
         // signed{max}+signed{max}
         static_assert(
                 identical(
-                        std::numeric_limits<elastic_integer<10>>::max()-std::numeric_limits<elastic_integer<9>>::max(),
+                        cnl::numeric_limits<elastic_integer<10>>::max()-cnl::numeric_limits<elastic_integer<9>>::max(),
                         elastic_integer<11>{512}),
                 "cnl::elastic_integer test failed");
     }
@@ -222,7 +222,7 @@ namespace {
     struct elastic_integer_test {
         using value_type = ElasticInteger;
         using narrowest = typename ElasticInteger::narrowest;
-        using numeric_limits = std::numeric_limits<value_type>;
+        using numeric_limits = cnl::numeric_limits<value_type>;
 
         static constexpr value_type lowest{Lowest};
         static constexpr value_type min{Min};
@@ -233,12 +233,12 @@ namespace {
 
         static constexpr int digits = value_type::digits;
         static constexpr bool is_signed = numeric_limits::is_signed;
-        static_assert(is_signed==std::numeric_limits<narrowest>::is_signed, "narrowest is different signedness");
+        static_assert(is_signed==cnl::numeric_limits<narrowest>::is_signed, "narrowest is different signedness");
 
         ////////////////////////////////////////////////////////////////////////////////
         // type traits
 
-        static_assert(is_signed==std::numeric_limits<typename value_type::rep>::is_signed,
+        static_assert(is_signed==cnl::numeric_limits<typename value_type::rep>::is_signed,
                 "signage of narrowest and rep should be the same");
         static_assert(!is_signed || numeric_limits::max()==-numeric_limits::lowest(), "type has most negative number");
         static_assert(!is_signed || -numeric_limits::max()==numeric_limits::lowest(), "type has most negative number");
@@ -262,7 +262,7 @@ namespace {
         using zero_squared_type = decltype(zero_squared);
         using zero_squared_narrowest = typename zero_squared_type::narrowest;
         static_assert(
-                std::numeric_limits<decltype(zero)>::is_signed==std::numeric_limits<decltype(zero*zero)>::is_signed,
+                cnl::numeric_limits<decltype(zero)>::is_signed==cnl::numeric_limits<decltype(zero*zero)>::is_signed,
                 "elastic_integer arithmetic test failed");
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -275,10 +275,10 @@ namespace {
     };
 
     static_assert(elastic_integer<7, int>{3}==3, "");
-    static_assert(std::numeric_limits<int8_t>::lowest()==-128, "");
+    static_assert(cnl::numeric_limits<int8_t>::lowest()==-128, "");
     static_assert(std::is_same<elastic_integer<7, int>::rep, int>::value, "");
-    static_assert(std::numeric_limits<elastic_integer<8, int>>::max()==255, "");
-    static_assert(std::numeric_limits<elastic_integer<8, int>>::lowest()==-255, "");
+    static_assert(cnl::numeric_limits<elastic_integer<8, int>>::max()==255, "");
+    static_assert(cnl::numeric_limits<elastic_integer<8, int>>::lowest()==-255, "");
 
     template
     struct elastic_integer_test<elastic_integer<7, int>, -127, 1, 127>;

--- a/src/test/elastic/precise/safe/precise_safe_elastic_integer.cpp
+++ b/src/test/elastic/precise/safe/precise_safe_elastic_integer.cpp
@@ -33,7 +33,7 @@ namespace cnl {
             class Input = int,
             class = _impl::enable_if_t<!_impl::is_integral_constant<Input>::value>>
     psei<
-            std::numeric_limits<Input>::digits,
+            numeric_limits<Input>::digits,
             OverflowTag, RoundingTag,
             Narrowest>
     constexpr make_psei(Input const& input)

--- a/src/test/fixed_point/elastic/elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/elastic_fixed_point.cpp
@@ -75,12 +75,12 @@ namespace {
 
 template<class T, bool IsSigned>
 struct test_traits {
-    static_assert(std::numeric_limits<T>::is_signed==IsSigned,
-                  "std::numeric_limits<T>::is_signed fails for give type, T");
+    static_assert(cnl::numeric_limits<T>::is_signed==IsSigned,
+                  "cnl::numeric_limits<T>::is_signed fails for give type, T");
     static_assert(is_signed<cnl::make_signed_t<T>>::value,
-                  "cnl::make_signed failed std::numeric_limits test; please reboot");
+                  "cnl::make_signed failed cnl::numeric_limits test");
     static_assert(!is_signed<cnl::make_unsigned_t<T>>::value,
-                  "cnl::make_unsigned failed std::numeric_limits test; please reboot");
+                  "cnl::make_unsigned failed cnl::numeric_limits test");
 };
 
 template
@@ -172,7 +172,7 @@ struct positive_elastic_test
     // core definitions
     using elastic_type = Elastic;
     using rep = typename elastic_type::rep;
-    using numeric_limits = std::numeric_limits<elastic_type>;
+    using numeric_limits = cnl::numeric_limits<elastic_type>;
 
     using signed_type = cnl::make_signed_t<elastic_type>;
     using unsigned_type = cnl::make_unsigned_t<elastic_type>;
@@ -194,11 +194,11 @@ struct positive_elastic_test
     ////////////////////////////////////////////////////////////////////////////////
     // test traits
 
-    static_assert(std::numeric_limits<elastic_type>::is_signed==std::numeric_limits<rep>::is_signed,
+    static_assert(cnl::numeric_limits<elastic_type>::is_signed==cnl::numeric_limits<rep>::is_signed,
                   "signedness of elastic_fixed_point type differs from underlying fixed-point type");
-    static_assert(std::numeric_limits<signed_type>::is_signed,
+    static_assert(cnl::numeric_limits<signed_type>::is_signed,
                   "signed version of elastic_fixed_point type is not signed");
-    static_assert(!std::numeric_limits<unsigned_type>::is_signed,
+    static_assert(!cnl::numeric_limits<unsigned_type>::is_signed,
                   "unsigned version of elastic_fixed_point type is signed");
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -208,19 +208,19 @@ struct positive_elastic_test
                   "not enough digits in rep type to represent elastic_fixed_point values");
 
     ////////////////////////////////////////////////////////////////////////////////
-    // test numeric_limits<elastic_fixed_point>
+    // test cnl::numeric_limits<elastic_fixed_point>
 
-    static_assert(min==elastic_type::from_data(rep{1}), "numeric_limits test failed");
-    static_assert(!is_less_than(max, min), "numeric_limits test failed");
-    static_assert(is_less_than(zero, min), "numeric_limits test failed");
-    static_assert(!is_less_than(zero, lowest), "numeric_limits test failed");
-    static_assert(is_less_than(lowest, min), "numeric_limits test failed");
-    static_assert(std::numeric_limits<elastic_type>::is_signed==numeric_limits::is_signed,
-                  "numeric_limits test failed");
-    static_assert(!numeric_limits::is_integer || (elastic_type{.5} != .5), "numeric_limits test failed");
+    static_assert(min==elastic_type::from_data(rep{1}), "cnl::numeric_limits test failed");
+    static_assert(!is_less_than(max, min), "cnl::numeric_limits test failed");
+    static_assert(is_less_than(zero, min), "cnl::numeric_limits test failed");
+    static_assert(!is_less_than(zero, lowest), "cnl::numeric_limits test failed");
+    static_assert(is_less_than(lowest, min), "cnl::numeric_limits test failed");
+    static_assert(cnl::numeric_limits<elastic_type>::is_signed==numeric_limits::is_signed,
+                  "cnl::numeric_limits test failed");
+    static_assert(!numeric_limits::is_integer || (elastic_type{.5} != .5), "cnl::numeric_limits test failed");
 
     static constexpr rep max_integer{max.data()};
-    static_assert(bit_count<typename rep::rep>(max_integer.data())==digits, "numeric_limits test failed");
+    static_assert(bit_count<typename rep::rep>(max_integer.data())==digits, "cnl::numeric_limits test failed");
 
     ////////////////////////////////////////////////////////////////////////////////
     // test comparison operators
@@ -245,10 +245,10 @@ struct positive_elastic_test
     ////////////////////////////////////////////////////////////////////////////////
     // test operator+
 
-    static_assert(std::numeric_limits<decltype(zero+zero)>::is_signed
-                  ==std::numeric_limits<elastic_type>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(zero+zero)>::is_signed
+                  ==cnl::numeric_limits<elastic_type>::is_signed,
                   "signedness is lost during add");
-    static_assert(std::numeric_limits<decltype(signed_type{zero}+unsigned_type{zero})>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(signed_type{zero}+unsigned_type{zero})>::is_signed,
                   "signedness is lost during add");
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -256,9 +256,9 @@ struct positive_elastic_test
 
     static_assert(is_less_than(max-min, max), "operator- test failed");
 
-    static_assert(std::numeric_limits<decltype(zero-zero)>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(zero-zero)>::is_signed,
                   "signedness is lost during subtract");
-    static_assert(std::numeric_limits<decltype(signed_type{zero}-unsigned_type{zero})>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(signed_type{zero}-unsigned_type{zero})>::is_signed,
                   "signedness is lost during subtract");
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -269,13 +269,13 @@ struct positive_elastic_test
     static_assert(is_equal_to(min*make_elastic_fixed_point(2_c), min+min), "operator* test failed");
     static_assert(is_equal_to(min*make_elastic_fixed_point(3_c), min+min+min), "operator* test failed");
 
-    static_assert(std::numeric_limits<decltype(zero*zero)>::is_signed
-                  ==std::numeric_limits<decltype(zero)>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(zero*zero)>::is_signed
+                  ==cnl::numeric_limits<decltype(zero)>::is_signed,
                   "signedness is lost during multiply");
-    static_assert(std::numeric_limits<decltype(zero*zero)>::is_signed
-                  ==std::numeric_limits<elastic_type>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(zero*zero)>::is_signed
+                  ==cnl::numeric_limits<elastic_type>::is_signed,
                   "signedness is lost during multiply");
-    static_assert(std::numeric_limits<decltype(signed_type{zero}*unsigned_type{zero})>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(signed_type{zero}*unsigned_type{zero})>::is_signed,
                   "signedness is lost during multiply");
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -285,10 +285,10 @@ struct positive_elastic_test
     static_assert(is_equal_to(min/make_elastic_fixed_point(1_c), min), "operator/ test failed");
     static_assert(is_equal_to((min+min)/make_elastic_fixed_point(2_c), min), "operator/ test failed");
     static_assert(is_equal_to((min+min+min)/make_elastic_fixed_point(3_c), min), "operator/ test failed");
-    static_assert(std::numeric_limits<decltype(zero/zero)>::is_signed
-                  ==std::numeric_limits<elastic_type>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(zero/zero)>::is_signed
+                  ==cnl::numeric_limits<elastic_type>::is_signed,
                   "signedness is lost during multiply");
-    static_assert(std::numeric_limits<decltype(signed_type{zero}/unsigned_type{zero})>::is_signed,
+    static_assert(cnl::numeric_limits<decltype(signed_type{zero}/unsigned_type{zero})>::is_signed,
                   "signedness is lost during multiply");
 };
 
@@ -308,7 +308,7 @@ struct signed_elastic_test :
 
     using elastic_type = Elastic;
     using rep = typename elastic_type::rep;
-    using numeric_limits = std::numeric_limits<elastic_type>;
+    using numeric_limits = cnl::numeric_limits<elastic_type>;
 
     ////////////////////////////////////////////////////////////////////////////////
     // useful constants
@@ -324,18 +324,18 @@ struct signed_elastic_test :
     // test traits
 
     // not much point testing negative value properties of unsigned type, eh?
-    static_assert(std::numeric_limits<elastic_type>::is_signed, "subject of test class is not reported as signed");
+    static_assert(cnl::numeric_limits<elastic_type>::is_signed, "subject of test class is not reported as signed");
     static_assert(is_same<cnl::make_signed_t<elastic_type>, elastic_type>::value,
                   "subject of test class is not reported as signed");
 
     ////////////////////////////////////////////////////////////////////////////////
-    // test numeric_limits<elastic_fixed_point>
+    // test cnl::numeric_limits<elastic_fixed_point>
 
-    static_assert(is_less_than(negative_min, min), "numeric_limits test failed");
+    static_assert(is_less_than(negative_min, min), "cnl::numeric_limits test failed");
     static_assert(is_equal_to(-max, lowest), "comparison test error");
     //static_assert(is_equal_to(elastic_type{min+max+lowest}, elastic_type{1}), "comparison test error");
-    static_assert(numeric_limits::is_signed, "numeric_limits test failed");
-    static_assert(!numeric_limits::is_integer || elastic_type{-.5} != -.5, "numeric_limits test failed");
+    static_assert(numeric_limits::is_signed, "cnl::numeric_limits test failed");
+    static_assert(!numeric_limits::is_integer || elastic_type{-.5} != -.5, "cnl::numeric_limits test failed");
 
     ////////////////////////////////////////////////////////////////////////////////
     // test comparison operators
@@ -375,7 +375,7 @@ struct unsigned_elastic_test :
     // core definitions
 
     using elastic_type = Elastic;
-    using numeric_limits = std::numeric_limits<elastic_type>;
+    using numeric_limits = cnl::numeric_limits<elastic_type>;
 
     ////////////////////////////////////////////////////////////////////////////////
     // useful constants
@@ -386,10 +386,10 @@ struct unsigned_elastic_test :
     static constexpr elastic_type lowest{numeric_limits::lowest()};
 
     ////////////////////////////////////////////////////////////////////////////////
-    // test numeric_limits<elastic_fixed_point>
+    // test cnl::numeric_limits<elastic_fixed_point>
 
-    static_assert(is_equal_to(lowest, zero), "numeric_limits test failed");
-    static_assert(is_less_than(lowest, min), "numeric_limits test failed");
+    static_assert(is_equal_to(lowest, zero), "cnl::numeric_limits test failed");
+    static_assert(is_less_than(lowest, min), "cnl::numeric_limits test failed");
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/test/fixed_point/elastic/make_elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/make_elastic_fixed_point.cpp
@@ -14,7 +14,7 @@ using cnl::_impl::identical;
 using namespace cnl::literals;
 using cnl::elastic_fixed_point;
 
-static constexpr auto int_digits = std::numeric_limits<int>::digits;
+static constexpr auto int_digits = cnl::numeric_limits<int>::digits;
 
 static_assert(identical(make_elastic_fixed_point(std::integral_constant<std::int64_t, -1>{}), cnl::elastic_fixed_point<1, 0, int>{-1}),
               "using too many bytes to represent -1");
@@ -27,7 +27,7 @@ static_assert(
 static_assert(
         identical(
                 make_elastic_fixed_point<std::uint8_t>(262143),
-                elastic_fixed_point<std::numeric_limits<decltype(262143)>::digits, 0, std::uint8_t>{262143}),
+                elastic_fixed_point<cnl::numeric_limits<decltype(262143)>::digits, 0, std::uint8_t>{262143}),
         "cnl::make_elastic_fixed_point test failed");
 
 static_assert(identical(make_elastic_fixed_point(std::integral_constant<int, 4>{}), elastic_fixed_point<1, 2>{4}), "");
@@ -75,7 +75,7 @@ static_assert(sizeof(make_elastic_fixed_point<signed char>(-255_c)) == 2, "using
 static_assert(sizeof(make_elastic_fixed_point<signed char>(-256_c)) == 1, "using too many bytes to represent -256");
 
 // some numbers are so big that you don't have the luxury of choosing
-static constexpr auto unsigned_limit = std::intmax_t{std::numeric_limits<unsigned>::max()} + 1;
+static constexpr auto unsigned_limit = std::intmax_t{cnl::numeric_limits<unsigned>::max()} + 1;
 static_assert(
         sizeof(make_elastic_fixed_point(std::integral_constant<std::intmax_t, unsigned_limit>())) == sizeof(int),
         "using too many bytes to represent 2^32");
@@ -113,7 +113,7 @@ struct make_elastic_test {
     static constexpr int lsz1 = lsz * 2;
     static_assert(Value==0 || Value!=((Value/lsz1)*lsz1), "fractional_digits is too high");
 
-    static_assert(std::numeric_limits<type>::is_signed, "signage doesn't match value");
+    static_assert(cnl::numeric_limits<type>::is_signed, "signage doesn't match value");
 //    static_assert(elastic_value==elastic_fixed_point<63, 0>{Value}, "make_elasticd value doesn't equal its source value");
 };
 
@@ -150,12 +150,12 @@ struct make_elastic_test<-10604499373>;
 template
 struct make_elastic_test<137858491849>;
 template
-struct make_elastic_test<std::numeric_limits<std::int64_t>::max()/2>;
+struct make_elastic_test<cnl::numeric_limits<std::int64_t>::max()/2>;
 template
-struct make_elastic_test<-std::numeric_limits<std::int64_t>::max()/2>;
+struct make_elastic_test<-cnl::numeric_limits<std::int64_t>::max()/2>;
 #if ! defined(_MSC_VER)
 template
-struct make_elastic_test<std::numeric_limits<std::int64_t>::max()>;
+struct make_elastic_test<cnl::numeric_limits<std::int64_t>::max()>;
 template
-struct make_elastic_test<-std::numeric_limits<std::int64_t>::max()>;
+struct make_elastic_test<-cnl::numeric_limits<std::int64_t>::max()>;
 #endif

--- a/src/test/fixed_point/elastic/precise/safe/precise_safe_elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/precise/safe/precise_safe_elastic_fixed_point.cpp
@@ -37,7 +37,7 @@ namespace cnl {
             class Narrowest = int,
             class Input = int>
     psefp<
-            std::numeric_limits<Input>::digits, 0,
+            numeric_limits<Input>::digits, 0,
             OverflowTag, RoundingTag,
             Narrowest>
     constexpr make_psefp(Input const& input)

--- a/src/test/fixed_point/fixed_point_common.h
+++ b/src/test/fixed_point/fixed_point_common.h
@@ -22,7 +22,7 @@
 
 using std::is_same;
 using std::declval;
-using std::numeric_limits;
+using cnl::numeric_limits;
 
 ////////////////////////////////////////////////////////////////////////////////
 // integer definitions
@@ -572,8 +572,8 @@ namespace test_operate {
 ////////////////////////////////////////////////////////////////////////////////
 // cnl::multiply
 
-static_assert(std::numeric_limits<uint8>::max()/5==51, "");
-static_assert(std::numeric_limits<uint8>::max()/3==85, "");
+static_assert(numeric_limits<uint8>::max()/5==51, "");
+static_assert(numeric_limits<uint8>::max()/3==85, "");
 
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
 static_assert(identical(multiply(fixed_point<uint8, -4>{2}, fixed_point<uint8, -4>{7.5}), fixed_point<uint16, -8>{15}),
@@ -802,7 +802,7 @@ namespace test_bitshift {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// std::numeric_limits<fixed_point<>>
+// cnl::numeric_limits<fixed_point<>>
 
 template<class Rep, int Exponent, class Min, class Max, class Lowest>
 constexpr bool test_numeric_limits(Min min, Max max, Lowest lowest)
@@ -810,6 +810,11 @@ constexpr bool test_numeric_limits(Min min, Max max, Lowest lowest)
     using fp = fixed_point<Rep, Exponent>;
     using nl = numeric_limits<fp>;
     using rnl = numeric_limits<Rep>;
+
+    static_assert(std::numeric_limits<Rep>::is_specialized,
+                  "std::numeric_limits<Rep>::is_specialized");
+    static_assert(std::numeric_limits<fp>::is_specialized,
+                  "std::numeric_limits<fixed_point<Rep>>::is_specialized");
 
     static_assert(nl::is_specialized, "numeric_limits<fixed_point>::is_specialized");
     static_assert(nl::is_signed==rnl::is_signed, "numeric_limits<fixed_point>::is_signed");
@@ -846,49 +851,49 @@ constexpr bool test_numeric_limits(Min min, Max max, Lowest lowest)
             && nl::denorm_min()==min;
 }
 
-static_assert(numeric_limits<fixed_point<test_int, -256>>::lowest() < -.1e-67, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, -256>>::min() > 0., "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, -256>>::min() < .1e-76, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, -256>>::max() > .1e-67, "std::numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, -256>>::lowest() < -.1e-67, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, -256>>::min() > 0., "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, -256>>::min() < .1e-76, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, -256>>::max() > .1e-67, "numeric_limits<fixed_point> test failed");
 
-static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::lowest() == 0., "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::min() > 0., "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::min() < .1e-76, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::max() > .1e-67, "std::numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::lowest() == 0., "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::min() > 0., "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::min() < .1e-76, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::max() > .1e-67, "numeric_limits<fixed_point> test failed");
 
 static_assert(test_numeric_limits<test_signed, -16>(1/65536.,
-        std::numeric_limits<test_signed>::max()/65536.,
-        std::numeric_limits<test_signed>::lowest()/65536.), "");
+        numeric_limits<test_signed>::max()/65536.,
+        numeric_limits<test_signed>::lowest()/65536.), "");
 
 static_assert(test_numeric_limits<test_unsigned, -16>(1/65536.,
-        std::numeric_limits<test_unsigned>::max()/65536.,
-        std::numeric_limits<test_unsigned>::lowest()/65536.), "");
+        numeric_limits<test_unsigned>::max()/65536.,
+        numeric_limits<test_unsigned>::lowest()/65536.), "");
 
 static_assert(test_numeric_limits<test_signed, 0>(1,
-        std::numeric_limits<test_signed>::max(),
-        std::numeric_limits<test_signed>::lowest()), "");
+        numeric_limits<test_signed>::max(),
+        numeric_limits<test_signed>::lowest()), "");
 
 static_assert(test_numeric_limits<test_unsigned, 0U>(1U,
-        std::numeric_limits<test_unsigned>::max(),
-        std::numeric_limits<test_unsigned>::lowest()), "");
+        numeric_limits<test_unsigned>::max(),
+        numeric_limits<test_unsigned>::lowest()), "");
 
 static_assert(test_numeric_limits<test_signed, 16>(65536.,
-        std::numeric_limits<test_signed>::max()*65536.,
-        std::numeric_limits<test_signed>::lowest()*65536.), "");
+        numeric_limits<test_signed>::max()*65536.,
+        numeric_limits<test_signed>::lowest()*65536.), "");
 
 static_assert(test_numeric_limits<test_unsigned, 16>(65536.,
-        std::numeric_limits<test_unsigned>::max()*65536.,
-        std::numeric_limits<test_unsigned>::lowest()*65536.), "");
+        numeric_limits<test_unsigned>::max()*65536.,
+        numeric_limits<test_unsigned>::lowest()*65536.), "");
 
-static_assert(numeric_limits<fixed_point<test_int, 256>>::lowest() < -1.e86, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, 256>>::min() > 1.e77, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, 256>>::min() < 1.e78, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, 256>>::max() > 1.e86, "std::numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, 256>>::lowest() < -1.e86, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, 256>>::min() > 1.e77, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, 256>>::min() < 1.e78, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_int, 256>>::max() > 1.e86, "numeric_limits<fixed_point> test failed");
 
-static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::lowest() == 0., "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::min() > 1.e77, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::min() < 1.e78, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::max() > 1.e86, "std::numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::lowest() == 0., "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::min() > 1.e77, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::min() < 1.e78, "numeric_limits<fixed_point> test failed");
+static_assert(numeric_limits<fixed_point<test_unsigned, 256>>::max() > 1.e86, "numeric_limits<fixed_point> test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // cnl::sqrt
@@ -954,7 +959,7 @@ struct FixedPointTesterOutsize {
             "mismatched exponent");
 
     // simply assignment to and from underlying representation
-    using numeric_limits = std::numeric_limits<fixed_point>;
+    using numeric_limits = cnl::numeric_limits<fixed_point>;
     static constexpr fixed_point min = cnl::_impl::from_rep<fixed_point>(rep(1));
     static_assert(min.data() == rep(1), "all Rep types should be able to store the number 1!");
 

--- a/src/test/fixed_point/fixed_point_math_common.h
+++ b/src/test/fixed_point/fixed_point_math_common.h
@@ -36,9 +36,9 @@ TEST(math, FPTESTFORMAT) {
     //TODO: it should be possible in a non-routine unit test to test over all
     //2^32 values of a 32-bit integer
     constexpr std::array<double, 13> fracts{ {
-        static_cast<double>(std::numeric_limits<fp>::min()), //As close to zero as possible
+        static_cast<double>(cnl::numeric_limits<fp>::min()), //As close to zero as possible
         0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
-            cnl::_impl::min(1., static_cast<double>(std::numeric_limits<fp>::max())) //As close to one as possible
+            cnl::_impl::min(1., static_cast<double>(cnl::numeric_limits<fp>::max())) //As close to one as possible
     } };
 
     for (int i = -cnl::_impl::fractional_digits<fp>::value; i < cnl::_impl::integer_digits<fp>::value; i++) {
@@ -65,7 +65,7 @@ TEST(math, FPTESTFORMAT) {
         }
     }
 
-    using numeric_limits = std::numeric_limits<fp>;
+    using numeric_limits = cnl::numeric_limits<fp>;
     if (numeric_limits::max() >= int(cnl::_impl::integer_digits<fp>::value)
             && numeric_limits::lowest() <= -cnl::_impl::fractional_digits<fp>::value) {
         //the largest exponent which's result doesn't overflow

--- a/src/test/fixed_point/precise_fixed_point.cpp
+++ b/src/test/fixed_point/precise_fixed_point.cpp
@@ -15,8 +15,8 @@ namespace {
     using precise_fixed_point = cnl::fixed_point<cnl::precise_integer<Rep, RoundingTag>, Exponent>;
 
     namespace test_numeric_limits {
-        static_assert(std::numeric_limits<precise_integer<>>::is_specialized, "std::numeric_limits<precise_integer<>> test failed");
-        static_assert(std::numeric_limits<precise_integer<>>::is_integer, "std::numeric_limits<precise_integer<>> test failed");
+        static_assert(cnl::numeric_limits<precise_integer<>>::is_specialized, "cnl::numeric_limits<precise_integer<>> test failed");
+        static_assert(cnl::numeric_limits<precise_integer<>>::is_integer, "cnl::numeric_limits<precise_integer<>> test failed");
     }
 
     namespace test_ctor {

--- a/src/test/num_traits.cpp
+++ b/src/test/num_traits.cpp
@@ -15,7 +15,7 @@ namespace {
 
     namespace test_digits_type {
         static_assert(std::is_same<
-                typename std::remove_cv<decltype(std::numeric_limits<void>::digits)>::type,
+                typename std::remove_cv<decltype(cnl::numeric_limits<void>::digits)>::type,
                 cnl::_digits_type>::value, "cnl::_digits_type test failed");
     }
 

--- a/src/test/number_test.h
+++ b/src/test/number_test.h
@@ -52,7 +52,7 @@ using cnl::_impl::identical;
 template<class Number>
 struct number_test {
     using value_type = Number;
-    using numeric_limits = std::numeric_limits<value_type>;
+    using numeric_limits = cnl::numeric_limits<value_type>;
 
     static constexpr value_type zero = cnl::_impl::from_rep<value_type>(0);
 #if defined(_MSC_VER)
@@ -62,9 +62,9 @@ struct number_test {
 #endif    
 
     ////////////////////////////////////////////////////////////////////////////////
-    // std::numeric_limits
+    // cnl::numeric_limits
 
-    static_assert(numeric_limits::is_specialized, "std::numeric_limits is not specialized for this type");
+    static_assert(numeric_limits::is_specialized, "numeric_limits is not specialized for this type");
 
     static constexpr value_type min{numeric_limits::min()};
     static constexpr value_type max{numeric_limits::max()};

--- a/src/test/numeric.cpp
+++ b/src/test/numeric.cpp
@@ -30,9 +30,9 @@ namespace {
                     "cnl::_numeric_impl::used_bits_positive test failed");
             static_assert(used_bits_positive(int16_t{32767})==15,
                     "cnl::_numeric_impl::used_bits_positive test failed");
-            static_assert(used_bits_positive(std::numeric_limits<int64_t>::max())==63,
+            static_assert(used_bits_positive(numeric_limits<int64_t>::max())==63,
                     "cnl::_numeric_impl::used_bits_positive test failed");
-            static_assert(used_bits_positive(std::numeric_limits<uint64_t>::max())==64,
+            static_assert(used_bits_positive(numeric_limits<uint64_t>::max())==64,
                     "cnl::_numeric_impl::used_bits_positive test failed");
         }
 
@@ -76,15 +76,15 @@ namespace {
         static_assert(_impl::used_bits_symmetric(int8_t{-8})==4, "cnl::_impl::used_bits_symmetric test failed");
         static_assert(_impl::used_bits_symmetric(int8_t{-9})==4, "cnl::_impl::used_bits_symmetric test failed");
         static_assert(_impl::used_bits_symmetric(int8_t{-128})==1, "cnl::_impl::used_bits_symmetric test failed");
-        static_assert(_impl::used_bits_symmetric(std::numeric_limits<int64_t>::lowest()+1)==63,
+        static_assert(_impl::used_bits_symmetric(numeric_limits<int64_t>::lowest()+1)==63,
                 "cnl::_impl::used_bits_symmetric test failed");
-        static_assert(_impl::used_bits_symmetric(std::numeric_limits<int64_t>::min()+1)==63,
+        static_assert(_impl::used_bits_symmetric(numeric_limits<int64_t>::min()+1)==63,
                 "cnl::_impl::used_bits_symmetric test failed");
-        static_assert(_impl::used_bits_symmetric(std::numeric_limits<int64_t>::max())==63,
+        static_assert(_impl::used_bits_symmetric(numeric_limits<int64_t>::max())==63,
                 "cnl::_impl::used_bits_symmetric test failed");
-        static_assert(_impl::used_bits_symmetric(std::numeric_limits<uint64_t>::min())==0,
+        static_assert(_impl::used_bits_symmetric(numeric_limits<uint64_t>::min())==0,
                 "cnl::_impl::used_bits_symmetric test failed");
-        static_assert(_impl::used_bits_symmetric(std::numeric_limits<uint64_t>::max())==64,
+        static_assert(_impl::used_bits_symmetric(numeric_limits<uint64_t>::max())==64,
                 "cnl::_impl::used_bits_symmetric test failed");
     }
 
@@ -102,19 +102,19 @@ namespace {
         static_assert(used_bits(int8_t{-8})==3, "cnl::used_bits test failed");
         static_assert(used_bits(int8_t{-9})==4, "cnl::used_bits test failed");
         static_assert(used_bits(int8_t{-128})==7, "cnl::used_bits test failed");
-        static_assert(used_bits(std::numeric_limits<int64_t>::lowest())==63,
+        static_assert(used_bits(numeric_limits<int64_t>::lowest())==63,
                 "cnl::used_bits test failed");
-        static_assert(used_bits(std::numeric_limits<int64_t>::lowest()+1)==63,
+        static_assert(used_bits(numeric_limits<int64_t>::lowest()+1)==63,
                 "cnl::used_bits test failed");
-        static_assert(used_bits(std::numeric_limits<int64_t>::min()+1)==63,
+        static_assert(used_bits(numeric_limits<int64_t>::min()+1)==63,
                 "cnl::used_bits test failed");
-        static_assert(used_bits(std::numeric_limits<int64_t>::max())==63,
+        static_assert(used_bits(numeric_limits<int64_t>::max())==63,
                 "cnl::used_bits test failed");
         static_assert(used_bits(UINT64_C(0))==0,
                 "cnl::used_bits test failed");
-        static_assert(used_bits(std::numeric_limits<uint64_t>::min())==0,
+        static_assert(used_bits(numeric_limits<uint64_t>::min())==0,
                 "cnl::used_bits test failed");
-        static_assert(used_bits(std::numeric_limits<uint64_t>::max())==64,
+        static_assert(used_bits(numeric_limits<uint64_t>::max())==64,
                 "cnl::used_bits test failed");
     }
 
@@ -131,17 +131,17 @@ namespace {
         static_assert(trailing_bits(int8_t{-8})==3, "cnl::trailing_bits test failed");
         static_assert(trailing_bits(int8_t{-9})==0, "cnl::trailing_bits test failed");
         static_assert(trailing_bits(int8_t{-128})==7, "cnl::trailing_bits test failed");
-        static_assert(trailing_bits(std::numeric_limits<int64_t>::lowest()+1)==0,
+        static_assert(trailing_bits(numeric_limits<int64_t>::lowest()+1)==0,
                 "cnl::trailing_bits test failed");
-        static_assert(trailing_bits(std::numeric_limits<int64_t>::min()+1)==0,
+        static_assert(trailing_bits(numeric_limits<int64_t>::min()+1)==0,
                 "cnl::trailing_bits test failed");
-        static_assert(trailing_bits(std::numeric_limits<int64_t>::max())==0,
+        static_assert(trailing_bits(numeric_limits<int64_t>::max())==0,
                 "cnl::trailing_bits test failed");
-        static_assert(trailing_bits(std::numeric_limits<uint64_t>::min())==0,
+        static_assert(trailing_bits(numeric_limits<uint64_t>::min())==0,
                 "cnl::trailing_bits test failed");
-        static_assert(trailing_bits(std::numeric_limits<uint64_t>::max())==0,
+        static_assert(trailing_bits(numeric_limits<uint64_t>::max())==0,
                 "cnl::trailing_bits test failed");
-        static_assert(trailing_bits(std::numeric_limits<uint64_t>::max())==0,
+        static_assert(trailing_bits(numeric_limits<uint64_t>::max())==0,
                 "cnl::trailing_bits test failed");
     }
 

--- a/src/test/overflow.cpp
+++ b/src/test/overflow.cpp
@@ -259,12 +259,12 @@ namespace {
         static_assert(identical(multiply(saturated_overflow, UINT16_C(576), INT32_C(22)),
                 decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::multiply test failed");
         static_assert(identical(
-                multiply(saturated_overflow, std::numeric_limits<int32_t>::max(), INT32_C(2)),
-                std::numeric_limits<int32_t>::max()), "cnl::multiply test failed");
+                multiply(saturated_overflow, cnl::numeric_limits<int32_t>::max(), INT32_C(2)),
+                cnl::numeric_limits<int32_t>::max()), "cnl::multiply test failed");
 
         // compare
         static_assert(cnl::_overflow_impl::operate<cnl::saturated_overflow_tag, cnl::_impl::less_than_op>()(-1, 1u), "cnl::_overflow_impl::operate test failed");
-        static_assert(identical(convert<short>(saturated_overflow, std::numeric_limits<double>::max()),
-                std::numeric_limits<short>::max()), "cnl::convert test failed");
+        static_assert(identical(convert<short>(saturated_overflow, cnl::numeric_limits<double>::max()),
+                                cnl::numeric_limits<short>::max()), "cnl::convert test failed");
     }
 }

--- a/src/test/precise/elastic/precise_elastic_integer.cpp
+++ b/src/test/precise/elastic/precise_elastic_integer.cpp
@@ -24,7 +24,7 @@ namespace cnl {
             class Narrowest = int,
             class Input = int>
     precise_elastic_integer<
-            std::numeric_limits<Input>::digits,
+            numeric_limits<Input>::digits,
             RoundingTag,
             Narrowest>
     constexpr make_precise_elastic(Input const& input)

--- a/src/test/safe/elastic/safe_elastic_integer.cpp
+++ b/src/test/safe/elastic/safe_elastic_integer.cpp
@@ -26,7 +26,7 @@ namespace cnl {
             class Narrowest = int,
             class Input = int>
     safe_elastic_integer<
-            std::numeric_limits<Input>::digits,
+            numeric_limits<Input>::digits,
             OverflowTag,
             Narrowest>
     constexpr make_safe_elastic(Input const& input)
@@ -49,12 +49,12 @@ namespace {
     namespace test_numeric_limits {
         using safe_saturating_integer_2 = cnl::safe_integer<cnl::elastic_integer<2, char>, cnl::saturated_overflow_tag>;
         static_assert(identical(
-                std::numeric_limits<safe_saturating_integer_2>::lowest(),
+                cnl::numeric_limits<safe_saturating_integer_2>::lowest(),
                 safe_saturating_integer_2{-3}), "");
         static_assert(identical(
-                std::numeric_limits<safe_saturating_integer_2>::max(),
+                cnl::numeric_limits<safe_saturating_integer_2>::max(),
                 safe_saturating_integer_2{3}), "");
-        static_assert(std::numeric_limits<safe_saturating_integer_2>::lowest() < std::numeric_limits<safe_saturating_integer_2>::max(), "");
+        static_assert(cnl::numeric_limits<safe_saturating_integer_2>::lowest() < cnl::numeric_limits<safe_saturating_integer_2>::max(), "");
     }
 
     namespace test_comparison {

--- a/src/test/safe/safe_integer.cpp
+++ b/src/test/safe/safe_integer.cpp
@@ -24,7 +24,6 @@ using cnl::_integer_impl::is_safe_integer;
 using cnl::safe_integer;
 using std::declval;
 using std::is_same;
-using std::numeric_limits;
 
 ////////////////////////////////////////////////////////////////////////////////
 // aliases for different partial instantiations of cnl::safe_integer
@@ -240,11 +239,11 @@ namespace test_equal {
 // arithmetic
 
 // addition
-static_assert(saturated_integer<int8_t>(saturated_integer<int8_t>(100)+saturated_integer<int8_t>(100))==numeric_limits<int8_t>::max(),
+static_assert(saturated_integer<int8_t>(saturated_integer<int8_t>(100)+saturated_integer<int8_t>(100))==cnl::numeric_limits<int8_t>::max(),
         "cnl::saturated_integer test failed");
 
 // subtraction
-static_assert(saturated_integer<uint8_t>(100)-saturated_integer<int16_t>(100000)==100-numeric_limits<int16_t>::max(),
+static_assert(saturated_integer<uint8_t>(100)-saturated_integer<int16_t>(100000)==100-cnl::numeric_limits<int16_t>::max(),
         "cnl::saturated_integer test failed");
 static_assert(throwing_integer<char>{0}-throwing_integer<char>{0}==throwing_integer<char>{0}, "");
 
@@ -267,43 +266,43 @@ static_assert(int16_t(31)/saturated_integer<int8_t>(-2)==-15, "cnl::saturated_in
 static_assert(is_same<decltype(declval<saturated_integer<>>() / declval<double>()), double>::value, "");
 
 ////////////////////////////////////////////////////////////////////////////////
-// numeric_limits
+// cnl::numeric_limits
 
-// std::numeric_limits<cnl::safe_integer<>>::is_integer
-static_assert(numeric_limits<cnl::safe_integer<int8_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<uint8_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<int16_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<uint16_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<int32_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<uint32_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<int64_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<uint64_t, cnl::saturated_overflow_tag>>::is_integer,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
+// cnl::numeric_limits<cnl::safe_integer<>>::is_integer
+static_assert(cnl::numeric_limits<cnl::safe_integer<int8_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<uint8_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<int16_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<uint16_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<int32_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<uint32_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<int64_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<uint64_t, cnl::saturated_overflow_tag>>::is_integer,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
 
-// std::numeric_limits<cnl::safe_integer<>>::is_signed
-static_assert(numeric_limits<cnl::safe_integer<int8_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(!numeric_limits<cnl::safe_integer<uint8_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<int16_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(!numeric_limits<cnl::safe_integer<uint16_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<int32_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(!numeric_limits<cnl::safe_integer<uint32_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(numeric_limits<cnl::safe_integer<int64_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
-static_assert(!numeric_limits<cnl::safe_integer<uint64_t, cnl::saturated_overflow_tag>>::is_signed,
-        "std::numeric_limits<cnl::safe_integer<>> test failed");
+// cnl::numeric_limits<cnl::safe_integer<>>::is_signed
+static_assert(cnl::numeric_limits<cnl::safe_integer<int8_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(!cnl::numeric_limits<cnl::safe_integer<uint8_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<int16_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(!cnl::numeric_limits<cnl::safe_integer<uint16_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<int32_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(!cnl::numeric_limits<cnl::safe_integer<uint32_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(cnl::numeric_limits<cnl::safe_integer<int64_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
+static_assert(!cnl::numeric_limits<cnl::safe_integer<uint64_t, cnl::saturated_overflow_tag>>::is_signed,
+        "cnl::numeric_limits<cnl::safe_integer<>> test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // traits


### PR DESCRIPTION
- mostly, this gets around the problem of patchy support for
  std::numeric_limits<__int128> and std::numeric_limits<unsigned __int128>
- derived from std equivalents for default template
- always explicitly specialized for 128-bit integer types