### PR TITLE
Remove use of "data" to access Rep value

### DIFF
--- a/include/cnl/bits/fixed_point_arithmetic.h
+++ b/include/cnl/bits/fixed_point_arithmetic.h
@@ -292,11 +292,11 @@ namespace cnl {
                 using result_type = typename params::result_type;
                 using result_rep = typename result_type::rep;
 
-                return result_type::from_data(
+                return _impl::from_rep<result_type>(
                         static_cast<result_rep>(
                                 Operation()(
-                                        static_cast<intermediate_lhs>(lhs).data(),
-                                        static_cast<intermediate_rhs>(rhs).data())));
+                                        _impl::to_rep(static_cast<intermediate_lhs>(lhs)),
+                                        _impl::to_rep(static_cast<intermediate_rhs>(rhs)))));
             };
         }
     }

--- a/include/cnl/bits/fixed_point_extras.h
+++ b/include/cnl/bits/fixed_point_extras.h
@@ -102,8 +102,8 @@ namespace cnl {
                 (x<fixed_point<Rep, Exponent>(0))
                 ? throw std::invalid_argument("cannot represent square root of negative value") :
 #endif
-                fixed_point<Rep, Exponent>::from_data(
-                        static_cast<Rep>(_impl::fp::extras::sqrt_solve1(widened_type{x}.data())));
+                _impl::from_rep<fixed_point<Rep, Exponent>>(
+                        static_cast<Rep>(_impl::fp::extras::sqrt_solve1(_impl::to_rep(widened_type{x}))));
     }
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -194,49 +194,49 @@ namespace cnl {
 
         static constexpr _value_type min() noexcept
         {
-            return _value_type::from_data(_rep{1});
+            return _impl::from_rep<_value_type>(_rep{1});
         }
 
         static constexpr _value_type max() noexcept
         {
-            return _value_type::from_data(_rep_numeric_limits::max());
+            return _impl::from_rep<_value_type>(_rep_numeric_limits::max());
         }
 
         static constexpr _value_type lowest() noexcept
         {
-            return _value_type::from_data(_rep_numeric_limits::lowest());
+            return _impl::from_rep<_value_type>(_rep_numeric_limits::lowest());
         }
 
         static constexpr bool is_integer = false;
 
         static constexpr _value_type epsilon() noexcept
         {
-            return _value_type::from_data(_rep{1});
+            return _impl::from_rep<_value_type>(_rep{1});
         }
 
         static constexpr _value_type round_error() noexcept
         {
-            return _value_type::from_data(_rep{0});
+            return _impl::from_rep<_value_type>(_rep{0});
         }
 
         static constexpr _value_type infinity() noexcept
         {
-            return _value_type::from_data(_rep{0});
+            return _impl::from_rep<_value_type>(_rep{0});
         }
 
         static constexpr _value_type quiet_NaN() noexcept
         {
-            return _value_type::from_data(_rep{0});
+            return _impl::from_rep<_value_type>(_rep{0});
         }
 
         static constexpr _value_type signaling_NaN() noexcept
         {
-            return _value_type::from_data(_rep{0});
+            return _impl::from_rep<_value_type>(_rep{0});
         }
 
         static constexpr _value_type denorm_min() noexcept
         {
-            return _value_type::from_data(_rep{1});
+            return _impl::from_rep<_value_type>(_rep{1});
         }
     };
 }

--- a/include/cnl/bits/fixed_point_operators.h
+++ b/include/cnl/bits/fixed_point_operators.h
@@ -21,10 +21,10 @@ namespace cnl {
     // negate
     template<class RhsRep, int RhsExponent>
     constexpr auto operator-(fixed_point<RhsRep, RhsExponent> const& rhs)
-    -> fixed_point<decltype(-rhs.data()), RhsExponent>
+    -> fixed_point<decltype(-_impl::to_rep(rhs)), RhsExponent>
     {
-        using result_type = fixed_point<decltype(-rhs.data()), RhsExponent>;
-        return result_type::from_data(-rhs.data());
+        using result_type = fixed_point<decltype(-_impl::to_rep(rhs)), RhsExponent>;
+        return _impl::from_rep<result_type>(-_impl::to_rep(rhs));
     }
 
     // add
@@ -98,9 +98,9 @@ namespace cnl {
 
         template<class Operator, class Rep, int Exponent, class = _impl::enable_if_t<Operator::is_comparison>>
         constexpr auto operate(fixed_point<Rep, Exponent> const& lhs, fixed_point<Rep, Exponent> const& rhs, Operator op)
-        -> decltype(op(lhs.data(), rhs.data()))
+        -> decltype(op(_impl::to_rep(lhs), _impl::to_rep(rhs)))
         {
-            return op(lhs.data(), rhs.data());
+            return op(_impl::to_rep(lhs), _impl::to_rep(rhs));
         };
     }
 
@@ -270,16 +270,16 @@ namespace cnl {
     // fixed_point, dynamic
     template<class LhsRep, int LhsExponent, class Rhs>
     constexpr auto operator<<(fixed_point<LhsRep, LhsExponent> const& lhs, Rhs const& rhs)
-    -> decltype(_impl::from_rep<fixed_point<decltype(lhs.data() << rhs), LhsExponent>>(lhs.data() << rhs))
+    -> decltype(_impl::from_rep<fixed_point<decltype(_impl::to_rep(lhs) << rhs), LhsExponent>>(_impl::to_rep(lhs) << rhs))
     {
-        return _impl::from_rep<fixed_point<decltype(lhs.data() << rhs), LhsExponent>>(lhs.data() << rhs);
+        return _impl::from_rep<fixed_point<decltype(_impl::to_rep(lhs) << rhs), LhsExponent>>(_impl::to_rep(lhs) << rhs);
     }
 
     template<class LhsRep, int LhsExponent, class Rhs>
     constexpr auto operator>>(fixed_point<LhsRep, LhsExponent> const& lhs, Rhs const& rhs)
-    -> decltype(_impl::from_rep<fixed_point<decltype(lhs.data() >> rhs), LhsExponent>>(lhs.data() >> rhs))
+    -> decltype(_impl::from_rep<fixed_point<decltype(_impl::to_rep(lhs) >> rhs), LhsExponent>>(_impl::to_rep(lhs) >> rhs))
     {
-        return _impl::from_rep<fixed_point<decltype(lhs.data() >> rhs), LhsExponent>>(lhs.data() >> rhs);
+        return _impl::from_rep<fixed_point<decltype(_impl::to_rep(lhs) >> rhs), LhsExponent>>(_impl::to_rep(lhs) >> rhs);
     }
 
     // fixed_point, const_integer
@@ -287,14 +287,14 @@ namespace cnl {
     constexpr fixed_point<LhsRep, LhsExponent+RhsValue>
     operator<<(fixed_point<LhsRep, LhsExponent> const& lhs, constant<RhsValue>)
     {
-        return fixed_point<LhsRep, LhsExponent+RhsValue>::from_data(lhs.data());
+        return _impl::from_rep<fixed_point<LhsRep, LhsExponent+RhsValue>>(_impl::to_rep(lhs));
     }
 
     template<class LhsRep, int LhsExponent, CNL_IMPL_CONSTANT_VALUE_TYPE RhsValue>
     constexpr fixed_point<LhsRep, LhsExponent-RhsValue>
     operator>>(fixed_point<LhsRep, LhsExponent> const& lhs, constant<RhsValue>)
     {
-        return fixed_point<LhsRep, LhsExponent-RhsValue>::from_data(lhs.data());
+        return _impl::from_rep<fixed_point<LhsRep, LhsExponent-RhsValue>>(_impl::to_rep(lhs));
     }
 }
 

--- a/include/cnl/bits/number_base.h
+++ b/include/cnl/bits/number_base.h
@@ -40,22 +40,8 @@ namespace cnl {
                 return static_cast<bool>(_rep);
             }
 
-            constexpr rep const& data() const
-            {
-                return _rep;
-            }
-
-#if (__cplusplus >= 201402L)
-            constexpr rep& data()
-            {
-                return _rep;
-            }
-#endif
-
-            static constexpr Derived from_data(rep const& r)
-            {
-                return Derived(r);
-            }
+            friend struct cnl::to_rep<_derived>;
+            friend struct cnl::to_rep<number_base<_derived, rep>>;
 
         private:
             rep _rep;
@@ -144,9 +130,9 @@ namespace cnl {
         // unary operate
         template<class Operator, class RhsDerived, class RhsRep>
         constexpr auto operate(number_base<RhsDerived, RhsRep> const& rhs, Operator op)
-        -> decltype(op(rhs.data()))
+        -> decltype(_impl::from_value<RhsDerived>(op(_impl::to_rep(rhs))))
         {
-            return op(rhs.data());
+            return _impl::from_value<RhsDerived>(op(_impl::to_rep(rhs)));
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -329,19 +315,18 @@ namespace cnl {
         using type = _impl::set_rep_t<Number, make_unsigned_t<_impl::get_rep_t<Number>>>;
     };
 
-    template<class Number>
-    struct from_rep<Number, _impl::enable_if_t<_impl::is_derived_from_number_base<Number>::value>> {
-        template<class Rep>
-        constexpr auto operator()(Rep const& rep) const -> Number {
-            return Number::from_data(static_cast<typename Number::rep>(rep));
+    template<class Derived, class Rep>
+    struct to_rep<_impl::number_base<Derived, Rep>> {
+        constexpr auto operator()(_impl::number_base<Derived, Rep> const& number) const -> Rep {
+            return number._rep;
         }
     };
 
     template<class Number>
     struct to_rep<Number, _impl::enable_if_t<_impl::is_derived_from_number_base<Number>::value>> {
-        constexpr auto operator()(typename Number::_derived const& number) const
-        -> decltype(number.data()){
-            return number.data();
+        constexpr auto operator()(Number const& number) const
+        -> typename Number::rep {
+            return number._rep;
         }
     };
 
@@ -370,22 +355,22 @@ namespace cnl {
 
         static constexpr _value_type min() noexcept
         {
-            return _value_type::from_data(_rep_numeric_limits::min());
+            return _impl::from_rep<_value_type>(_rep_numeric_limits::min());
         }
 
         static constexpr _value_type max() noexcept
         {
-            return _value_type::from_data(_rep_numeric_limits::max());
+            return _impl::from_rep<_value_type>(_rep_numeric_limits::max());
         }
 
         static constexpr _value_type lowest() noexcept
         {
-            return _value_type::from_data(_rep_numeric_limits::lowest());
+            return _impl::from_rep<_value_type>(_rep_numeric_limits::lowest());
         }
 
         static constexpr _value_type epsilon() noexcept
         {
-            return _value_type::from_data(_rep_numeric_limits::round_error());
+            return _impl::from_rep<_value_type>(_rep_numeric_limits::round_error());
         }
 
         static constexpr _value_type round_error() noexcept

--- a/include/cnl/precise_integer.h
+++ b/include/cnl/precise_integer.h
@@ -40,7 +40,7 @@ namespace cnl {
         template<class T>
         constexpr explicit operator T() const
         {
-            return static_cast<T>(super::data());
+            return static_cast<T>(_impl::to_rep(*this));
         }
     };
 
@@ -100,10 +100,10 @@ namespace cnl {
         constexpr auto operate_common_tag(
                 precise_integer<LhsRep, RoundingTag> const& lhs,
                 precise_integer<RhsRep, RoundingTag> const& rhs)
-        -> decltype(from_rep<precise_integer<op_result<Operator, LhsRep, RhsRep>, RoundingTag>>(Operator()(lhs.data(), rhs.data())))
+        -> decltype(from_rep<precise_integer<op_result<Operator, LhsRep, RhsRep>, RoundingTag>>(Operator()(to_rep(lhs), to_rep(rhs))))
         {
             using result_type = precise_integer<op_result<Operator, LhsRep, RhsRep>, RoundingTag>;
-            return from_rep<result_type>(Operator()(lhs.data(), rhs.data()));
+            return from_rep<result_type>(Operator()(to_rep(lhs), to_rep(rhs)));
         }
 
         // for arithmetic operands with different policies
@@ -111,9 +111,9 @@ namespace cnl {
         constexpr auto operate_common_tag(
                 precise_integer<LhsRep, RoundingTag> const& lhs,
                 precise_integer<RhsRep, RoundingTag> const& rhs)
-        -> decltype(Operator()(lhs.data(), rhs.data()))
+        -> decltype(Operator()(to_rep(lhs), to_rep(rhs)))
         {
-            return Operator()(lhs.data(), rhs.data());
+            return Operator()(to_rep(lhs), to_rep(rhs));
         }
 
         // for arithmetic operands with different policies

--- a/include/cnl/safe_integer.h
+++ b/include/cnl/safe_integer.h
@@ -23,17 +23,17 @@ namespace cnl {
     template <class LhsRep, class LhsOverflowTag, class RhsRep, class RhsOverflowTag> \
     constexpr auto operator OP (safe_integer<LhsRep, LhsOverflowTag> const& lhs, safe_integer<RhsRep, RhsOverflowTag> const& rhs) \
     -> safe_integer<LhsRep, LhsOverflowTag> { \
-        return lhs.data() OP rhs.data(); } \
+        return _impl::to_rep(lhs) OP _impl::to_rep(rhs); } \
     \
     template <class Lhs, class RhsRep, class RhsOverflowTag, _impl::enable_if_t<std::is_fundamental<Lhs>::value, int> dummy = 0> \
     constexpr auto operator OP (Lhs const& lhs, safe_integer<RhsRep, RhsOverflowTag> const& rhs) \
     -> Lhs { \
-        return lhs OP rhs.data(); } \
+        return lhs OP _impl::to_rep(rhs); } \
     \
     template <class LhsRep, class LhsOverflowTag, class Rhs, _impl::enable_if_t<std::is_fundamental<Rhs>::value, int> dummy = 0> \
     constexpr auto operator OP (safe_integer<LhsRep, LhsOverflowTag> const& lhs, Rhs const& rhs) \
     -> safe_integer<LhsRep, LhsOverflowTag> { \
-        return safe_integer<LhsRep, LhsOverflowTag>(lhs.data() OP rhs); }
+        return safe_integer<LhsRep, LhsOverflowTag>(_impl::to_rep(lhs) OP rhs); }
 
     ////////////////////////////////////////////////////////////////////////////////
     // forward-declarations
@@ -130,7 +130,7 @@ namespace cnl {
 
         template<class RhsRep, class RhsOverflowTag>
         constexpr safe_integer(safe_integer<RhsRep, RhsOverflowTag> const& rhs)
-                :safe_integer(rhs.data())
+                :safe_integer(_impl::to_rep(rhs))
         {
         }
 
@@ -152,7 +152,7 @@ namespace cnl {
         template<class T>
         constexpr explicit operator T() const
         {
-            return static_cast<T>(_base::data());
+            return static_cast<T>(_impl::to_rep(*this));
         }
     };
 
@@ -223,9 +223,9 @@ namespace cnl {
                 OperatorTag,
                 safe_integer<LhsRep, OverflowTag> const& lhs,
                 safe_integer<RhsRep, OverflowTag> const& rhs)
-        -> decltype(make_safe_integer<OverflowTag>(_overflow_impl::operate<OverflowTag, OperatorTag>()(lhs.data(), rhs.data())))
+        -> decltype(make_safe_integer<OverflowTag>(_overflow_impl::operate<OverflowTag, OperatorTag>()(to_rep(lhs), to_rep(rhs))))
         {
-            return make_safe_integer<OverflowTag>(_overflow_impl::operate<OverflowTag, OperatorTag>()(lhs.data(), rhs.data()));
+            return make_safe_integer<OverflowTag>(_overflow_impl::operate<OverflowTag, OperatorTag>()(to_rep(lhs), to_rep(rhs)));
         }
 
         // for comparison operands with a common overflow tag
@@ -235,9 +235,9 @@ namespace cnl {
                 OperatorTag,
                 safe_integer<LhsRep, OverflowTag> const& lhs,
                 safe_integer<RhsRep, OverflowTag> const& rhs)
-        -> decltype(_overflow_impl::operate<OverflowTag, OperatorTag>()(lhs.data(), rhs.data()))
+        -> decltype(_overflow_impl::operate<OverflowTag, OperatorTag>()(to_rep(lhs), to_rep(rhs)))
         {
-            return _overflow_impl::operate<OverflowTag, OperatorTag>()(lhs.data(), rhs.data());
+            return _overflow_impl::operate<OverflowTag, OperatorTag>()(to_rep(lhs), to_rep(rhs));
         }
     
         // for arithmetic operands with different policies

--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -19,7 +19,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
   set(PROFILE_ENABLED_FLAGS "/Oy-")
   set(PROFILE_DISABLED_FLAGS "")
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-  set(MISC_FLAGS "-pthread -Wall -Wextra -Werror -Wfatal-errors")
+  set(MISC_FLAGS "-pthread -Wall -Wextra -Werror")
 
   set(CPP17_ENABLED_FLAGS "-std=c++17")
 

--- a/src/test/boost.simd.cpp
+++ b/src/test/boost.simd.cpp
@@ -40,7 +40,7 @@ namespace {
 namespace cnl {
     template<class T, std::size_t N, int Exponent>
     bool operator==(fpp<T, N, Exponent> const& lhs, fpp<T, N, Exponent> const& rhs) noexcept {
-        return boost::simd::compare_equal(lhs.data(), rhs.data());
+        return boost::simd::compare_equal(_impl::to_rep(lhs), _impl::to_rep(rhs));
     }
 
     template<class T, std::size_t N, int Exponent>

--- a/src/test/fixed_point/elastic/elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/elastic_fixed_point.cpp
@@ -214,7 +214,7 @@ struct positive_elastic_test
     ////////////////////////////////////////////////////////////////////////////////
     // test cnl::numeric_limits<elastic_fixed_point>
 
-    static_assert(min==elastic_type::from_data(rep{1}), "cnl::numeric_limits test failed");
+    static_assert(min==cnl::_impl::from_rep<elastic_type>(rep{1}), "cnl::numeric_limits test failed");
     static_assert(!is_less_than(max, min), "cnl::numeric_limits test failed");
     static_assert(is_less_than(zero, min), "cnl::numeric_limits test failed");
     static_assert(!is_less_than(zero, lowest), "cnl::numeric_limits test failed");
@@ -223,8 +223,10 @@ struct positive_elastic_test
                   "cnl::numeric_limits test failed");
     static_assert(!numeric_limits::is_integer || (elastic_type{.5} != .5), "cnl::numeric_limits test failed");
 
-    static constexpr rep max_integer{max.data()};
-    static_assert(bit_count<typename rep::rep>(max_integer.data())==digits, "cnl::numeric_limits test failed");
+    static constexpr rep max_integer{cnl::_impl::to_rep(max)};
+#if ! defined(_MSC_VER)
+    static_assert(bit_count<typename rep::rep>(cnl::_impl::to_rep(max_integer))==digits, "cnl::numeric_limits test failed");
+#endif
 
     ////////////////////////////////////////////////////////////////////////////////
     // test comparison operators

--- a/src/test/fixed_point/fixed_point_common.h
+++ b/src/test/fixed_point/fixed_point_common.h
@@ -964,7 +964,9 @@ struct FixedPointTesterOutsize {
     // simply assignment to and from underlying representation
     using numeric_limits = cnl::numeric_limits<fixed_point>;
     static constexpr fixed_point min = cnl::_impl::from_rep<fixed_point>(rep(1));
-    static_assert(min.data() == rep(1), "all Rep types should be able to store the number 1!");
+#if ! defined(_MSC_VER)
+    static_assert(cnl::_impl::to_rep(min) == rep(1), "all Rep types should be able to store the number 1!");
+#endif
 
     // unary common_type_t
     static_assert(is_same<

--- a/src/test/fixed_point/fixed_point_math_common.h
+++ b/src/test/fixed_point/fixed_point_math_common.h
@@ -25,8 +25,8 @@ TEST(math, FPTESTFORMAT) {
 #if (FPTESTEXP < 0)
     for (int i = std::max(-cnl::_impl::fractional_digits<fp>::value, -(cnl::_impl::shift_left<cnl::_impl::integer_digits<fp>::value, int32_t>(1)) + 1); i < std::min(0, cnl::_impl::integer_digits<fp>::value - 1); i++) {
         fp lhs{ exp2(fp{ i }) };
-        EXPECT_EQ(lhs, fp::from_data(1 << (-fp::exponent + i)))
-            << "i = " << i << ", fixed point raw: " << lhs.data() << " should be: " << (1 << (-fp::exponent + i))
+        EXPECT_EQ(lhs, cnl::_impl::from_rep<fp>(1 << (-fp::exponent + i)))
+            << "i = " << i << ", fixed point raw: " << cnl::_impl::to_rep(lhs) << " should be: " << (1 << (-fp::exponent + i))
             ;
     }
 #endif
@@ -57,8 +57,9 @@ TEST(math, FPTESTFORMAT) {
             //Check for at most 1 LSB error
             fp lhs{ exp2(fp{ fprep }) };
             fp rhs{ exp2(doublerep) }; //Will use the double overload
-            EXPECT_LE(std::abs(lhs.data() - rhs.data()), 1)
-                << "fail at " << i + frac << ", fixed point raw: " << lhs.data() << " double raw " << rhs.data()
+            EXPECT_LE(std::abs(cnl::_impl::to_rep(lhs)-cnl::_impl::to_rep(rhs)), 1)
+                            << "fail at " << i+frac << ", fixed point raw: " << cnl::_impl::to_rep(lhs)
+                            << " double raw " << cnl::_impl::to_rep(rhs)
                 ;
             //bit-accurate:: not without a rounding multiply
             //EXPECT_EQ(exp2(fp{fprep}), fp{exp2(doublerep)});
@@ -69,17 +70,18 @@ TEST(math, FPTESTFORMAT) {
     if (numeric_limits::max() >= int(cnl::_impl::integer_digits<fp>::value)
             && numeric_limits::lowest() <= -cnl::_impl::fractional_digits<fp>::value) {
         //the largest exponent which's result doesn't overflow
-        auto maximum = fp::from_data(fp{ cnl::_impl::integer_digits<fp>::value }.data() - 1);
+        auto maximum = cnl::_impl::from_rep<fp>(cnl::_impl::to_rep(fp{cnl::_impl::integer_digits<fp>::value})-1);
 
         //The next-to-smallest exponent whose result doesn't overflow
         //(The very smallest was already tested with the integer exponents)
-        auto minimum = fp::from_data(fp{ -cnl::_impl::fractional_digits<fp>::value }.data() + 1);
+        auto minimum = cnl::_impl::from_rep<fp>(cnl::_impl::to_rep(fp{-cnl::_impl::fractional_digits<fp>::value})+1);
 
         double doublerep{ maximum };
         double doublerepmini{ minimum };
 
-        EXPECT_LE(std::abs(exp2(maximum).data() - fp{ exp2(doublerep) }.data()), 1)
-        << "fixed point raw: " << exp2(maximum).data() << ", double raw: " << fp{ exp2(doublerep) }.data();
+        EXPECT_LE(std::abs(cnl::_impl::to_rep(exp2(maximum))-cnl::_impl::to_rep(fp{exp2(doublerep)})), 1)
+                        << "fixed point raw: " << cnl::_impl::to_rep(exp2(maximum))
+                        << ", double raw: " << cnl::_impl::to_rep(fp{exp2(doublerep)});
 
         EXPECT_EQ(exp2(minimum), fp{ exp2(doublerepmini) });
     }

--- a/src/test/fixed_point/precise_fixed_point.cpp
+++ b/src/test/fixed_point/precise_fixed_point.cpp
@@ -20,11 +20,9 @@ namespace {
     }
 
     namespace test_ctor {
-        using cnl::_impl::from_rep;
-
         static_assert(identical(
-                precise_fixed_point<>(-8).data(),
+                cnl::_impl::to_rep(precise_fixed_point<>(-8)),
                 precise_integer<>(-8)), "precise_fixed_point ctor test failed");
-        static_assert(precise_fixed_point<>(0) == from_rep<precise_fixed_point<>>(0), "precise_fixed_point ctor test failed");
+        static_assert(precise_fixed_point<>(0) == cnl::_impl::from_rep<precise_fixed_point<>>(0), "precise_fixed_point ctor test failed");
     }
 }

--- a/src/test/index.cpp
+++ b/src/test/index.cpp
@@ -45,7 +45,7 @@ void declaration_example()
     auto x = fixed_point<int, -1>{3.5};
 
     // under the hood, x stores a whole number
-    cout << x.data() << endl;  // "7"
+    cout << to_rep<fixed_point<int, -1>>()(x) << endl;  // "7"
 
     // but it multiplies that whole number by 2^-1 to produce a real number
     cout << x << endl;  // "3.5"

--- a/src/test/safe/safe_integer.cpp
+++ b/src/test/safe/safe_integer.cpp
@@ -191,8 +191,8 @@ namespace {
     static_assert(identical(
         cnl::make_safe_integer<cnl::saturated_overflow_tag>(cnl::_overflow_impl::operate
                 <cnl::saturated_overflow_tag, multiply_op>()(
-            cnl::safe_integer<signed char, cnl::saturated_overflow_tag>{30}.data(),
-            cnl::safe_integer<signed char, cnl::saturated_overflow_tag>{40}.data())),
+            cnl::_impl::to_rep(cnl::safe_integer<signed char, cnl::saturated_overflow_tag>{30}),
+            cnl::_impl::to_rep(cnl::safe_integer<signed char, cnl::saturated_overflow_tag>{40}))),
         cnl::safe_integer<int, cnl::saturated_overflow_tag>{1200}), "");
 
     static_assert(identical(


### PR DESCRIPTION
- data means something subtly different
- NumberType::data() replaced with to_rep
- NumberType::from_data() replaced with from_rep
- addresses #52