### PR TITLE
Shift simplification

### DIFF
--- a/include/cnl/auxiliary/boost.multiprecision.h
+++ b/include/cnl/auxiliary/boost.multiprecision.h
@@ -10,6 +10,7 @@
 #if !defined(CNL_BOOST_MULTIPRECISION_H)
 #define CNL_BOOST_MULTIPRECISION_H 1
 
+#include <cnl/constant.h>
 #include <cnl/num_traits.h>
 
 #include <boost/multiprecision/cpp_int.hpp>
@@ -95,6 +96,24 @@ namespace cnl {
     // cnl::unsigned_multiprecision - an integer of arbitrary size
     template<unsigned NumDigits = digits<int>::value>
     using multiprecision = signed_multiprecision<NumDigits>;
+
+    ////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////
+    // _bmp bitwise shift operators
+
+    template<unsigned NumBits, _bmp::cpp_integer_type SignType, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
+    constexpr auto operator<<(_sized_integer_impl::number<NumBits, SignType> const& lhs, constant<Value>)
+    -> decltype(lhs << Value)
+    {
+        return lhs << Value;
+    }
+
+    template<unsigned NumBits, _bmp::cpp_integer_type SignType, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
+    constexpr auto operator>>(_sized_integer_impl::number<NumBits, SignType> const& lhs, constant<Value>)
+    -> decltype(lhs >> Value)
+    {
+        return lhs >> Value;
+    }
 }
 
 #endif  // CNL_BOOST_MULTIPRECISION_H

--- a/include/cnl/auxiliary/boost.multiprecision.h
+++ b/include/cnl/auxiliary/boost.multiprecision.h
@@ -79,15 +79,18 @@ namespace cnl {
         template<unsigned NumBits, _bmp::cpp_integer_type SignType>
         using backend = _bmp::cpp_int_backend<
                 NumBits, NumBits, SignType, _bmp::unchecked, void>;
+
+        template<unsigned NumBits, _bmp::cpp_integer_type SignType>
+        using number = _bmp::number<_sized_integer_impl::backend<NumBits, SignType>, _bmp::et_off>;
     }
 
     // cnl::signed_multiprecision - a signed integer of arbitrary size
     template<unsigned NumDigits = digits<int>::value>
-    using signed_multiprecision = _bmp::number<_sized_integer_impl::backend<NumDigits+1, _bmp::signed_magnitude>, _bmp::et_off>;
+    using signed_multiprecision = _sized_integer_impl::number<NumDigits+1, _bmp::signed_magnitude>;
 
     // cnl::unsigned_multiprecision - an unsigned integer of arbitrary size
     template<unsigned NumDigits = digits<unsigned>::value>
-    using unsigned_multiprecision = _bmp::number<_sized_integer_impl::backend<NumDigits, _bmp::unsigned_magnitude>, _bmp::et_off>;
+    using unsigned_multiprecision = _sized_integer_impl::number<NumDigits, _bmp::unsigned_magnitude>;
 
     // cnl::unsigned_multiprecision - an integer of arbitrary size
     template<unsigned NumDigits = digits<int>::value>

--- a/include/cnl/auxiliary/boost.multiprecision.h
+++ b/include/cnl/auxiliary/boost.multiprecision.h
@@ -52,6 +52,17 @@ namespace cnl {
         using type = _bmp::cpp_int_backend<width, width, SignType, Checked, Allocator>;
     };
 
+    template<unsigned NumBits, _bmp::cpp_integer_type SignType, _bmp::cpp_int_check_type Checked, class Value>
+    struct from_value<_bmp::cpp_int_backend<NumBits, NumBits, SignType, Checked>, Value> {
+    private:
+        static constexpr auto _digits = digits<Value>::value;
+        static constexpr auto _is_signed = is_signed<Value>::value;
+        static constexpr auto _bits = _digits + _is_signed;
+        static constexpr auto _sign_type = _is_signed ? _bmp::signed_magnitude : _bmp::unsigned_magnitude;
+    public:
+        using type = _bmp::cpp_int_backend<_bits, _bits, _sign_type, Checked, void>;
+    };
+
     template<class Backend, _bmp::expression_template_option ExpressionTemplates>
     struct make_signed<_bmp::number<Backend, ExpressionTemplates>> {
         using type = _bmp::number<make_signed_t<Backend>, ExpressionTemplates>;
@@ -70,6 +81,20 @@ namespace cnl {
     template<class Backend, _bmp::expression_template_option ExpressionTemplates, _digits_type MinNumDigits>
     struct set_digits<_bmp::number<Backend, ExpressionTemplates>, MinNumDigits> {
         using type = _bmp::number<set_digits_t<Backend, MinNumDigits>, ExpressionTemplates>;
+    };
+
+    template<class Backend, _bmp::expression_template_option ExpressionTemplates, class Value>
+    struct from_value<_bmp::number<Backend, ExpressionTemplates>, Value> {
+        using type = _bmp::number<from_value_t<Backend, Value>, ExpressionTemplates>;
+    };
+
+    template<int Bits, class Backend, _bmp::expression_template_option ExpressionTemplates>
+    struct shift<Bits, 2, _bmp::number<Backend, ExpressionTemplates>> {
+        constexpr auto operator()(_bmp::number<Backend, ExpressionTemplates> const& s) const
+        -> decltype((Bits>=0) ? s << Bits : s >> -Bits)
+        {
+            return (Bits>=0) ? s << Bits : s >> -Bits;
+        }
     };
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/cnl/auxiliary/boost.simd.h
+++ b/include/cnl/auxiliary/boost.simd.h
@@ -26,6 +26,10 @@ namespace cnl {
         using type = boost::simd::pack<set_digits_t<T, Digits>, N>;
     };
 
+    template<int Digits, int Radix, class T, std::size_t N>
+    struct shift<Digits, Radix, boost::simd::pack<T, N>> : _impl::default_scale<Digits, Radix, boost::simd::pack<T, N>> {
+    };
+
     template<class T, std::size_t N>
     struct make_signed<boost::simd::pack<T, N>> {
         using type = boost::simd::pack<make_signed_t<T>, N>;

--- a/include/cnl/bits/fixed_point/constants.h
+++ b/include/cnl/bits/fixed_point/constants.h
@@ -26,9 +26,9 @@ namespace cnl {
         template<typename Rep, int Exponent>
         constexpr auto pi(int const max_iterations) {
             using fp = fixed_point<Rep, Exponent>;
-            constexpr auto four = fixed_point<Rep, 3 - digits<Rep>::value>{4};
+            constexpr auto four = fixed_point<Rep, 3 - digits<Rep>::value>{4.};
 
-            auto previous = fp{3};
+            auto previous = fp{3.};
             for(auto n = 2; n != (max_iterations << 1); n += 4) {
                 auto const addend     = four / ((n+0L) * (n+1L) * (n+2L));
                 auto const subtrahend = four / ((n+2L) * (n+3L) * (n+4L));
@@ -49,9 +49,9 @@ namespace cnl {
         template<typename Rep, int Exponent>
         constexpr auto e(int const max_iterations) {
             using fp = fixed_point<Rep, Exponent>;
-            constexpr auto one = fixed_point<Rep, 1 - digits<Rep>::value>{1};
+            constexpr auto one = fixed_point<Rep, 1 - digits<Rep>::value>{1.};
 
-            auto previous = fp{2};
+            auto previous = fp{2.};
             auto factor = 2;
             for (auto n = 2; n != max_iterations; ++ n, factor *= n) {
                 auto const addend = one / factor;

--- a/include/cnl/bits/fixed_point/extras.h
+++ b/include/cnl/bits/fixed_point/extras.h
@@ -95,14 +95,14 @@ namespace cnl {
     sqrt(fixed_point<Rep, Exponent> const& x)
     {
         using widened_rep = set_digits_t<Rep, digits<Rep>::value*2>;
-        using widened_type = fixed_point<widened_rep, Exponent*2>;
         return
 #if defined(CNL_EXCEPTIONS_ENABLED)
-                (x<fixed_point<Rep, Exponent>(0))
+                (x<_impl::from_rep<fixed_point<Rep, Exponent>>(0))
                 ? throw std::invalid_argument("cannot represent square root of negative value") :
 #endif
-                _impl::from_rep<fixed_point<Rep, Exponent>>(
-                        for_rep<widened_rep>(_impl::fp::extras::sqrt_solve1(), _impl::to_rep(widened_type{x})));
+                _impl::from_rep<fixed_point<Rep, Exponent>>(for_rep<widened_rep>(
+                        _impl::fp::extras::sqrt_solve1(),
+                        _impl::scale<-Exponent>(static_cast<widened_rep>(_impl::to_rep(x)))));
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/cnl/bits/fixed_point/named.h
+++ b/include/cnl/bits/fixed_point/named.h
@@ -98,16 +98,14 @@ namespace cnl {
     namespace _divide_impl {
         template<class Lhs, class Rhs>
         struct params {
-            using lhs_type = typename _named_impl::fixed_point_type<Lhs>::type;
-            using rhs_type = typename _named_impl::fixed_point_type<Rhs>::type;
-            using lhs_rep = typename lhs_type::rep;
-            using rhs_rep = typename rhs_type::rep;
+            using lhs_rep = typename Lhs::rep;
+            using rhs_rep = typename Rhs::rep;
             using rep_op_result = _impl::op_result<_impl::multiply_op, lhs_rep, rhs_rep>;
 
             static constexpr int integer_digits =
-                    _impl::integer_digits<lhs_type>::value + _impl::fractional_digits<rhs_type>::value;
+                    _impl::integer_digits<Lhs>::value + _impl::fractional_digits<Rhs>::value;
             static constexpr int fractional_digits =
-                    _impl::fractional_digits<lhs_type>::value + _impl::integer_digits<rhs_type>::value;
+                    _impl::fractional_digits<Lhs>::value + _impl::integer_digits<Rhs>::value;
             static constexpr int necessary_digits = integer_digits + fractional_digits;
             static constexpr bool is_signed =
                     numeric_limits<lhs_rep>::is_signed || numeric_limits<rhs_rep>::is_signed;
@@ -120,11 +118,10 @@ namespace cnl {
 
             static constexpr int rep_exponent = -fractional_digits;
 
-            static constexpr int intermediate_exponent_lhs = lhs_type::exponent - digits<rhs_type>::value;
+            static constexpr int intermediate_exponent_lhs = Lhs::exponent - digits<Rhs>::value;
 
             using result_type = fixed_point<rep_type, rep_exponent>;
             using intermediate_lhs = fixed_point<rep_type, intermediate_exponent_lhs>;
-            using intermediate_rhs = rhs_type;
         };
 
         template<class Lhs, class Rhs>
@@ -136,13 +133,12 @@ namespace cnl {
             -> typename params<fixed_point<LhsRep, LhsExponent>, fixed_point<RhsRep, RhsExponent>>::result_type {
                 using params = params<fixed_point<LhsRep, LhsExponent>, fixed_point<RhsRep, RhsExponent>>;
                 using intermediate_lhs = typename params::intermediate_lhs;
-                using intermediate_rhs = typename params::intermediate_rhs;
                 using result_type = typename params::result_type;
                 using result_rep = typename result_type::rep;
 
                 return _impl::from_rep<result_type>(
                         static_cast<result_rep>(_impl::to_rep(static_cast<intermediate_lhs>(lhs))
-                                                / _impl::to_rep(static_cast<intermediate_rhs>(rhs))));
+                                                / _impl::to_rep(rhs)));
             }
         };
 

--- a/include/cnl/bits/fixed_point/named.h
+++ b/include/cnl/bits/fixed_point/named.h
@@ -100,7 +100,7 @@ namespace cnl {
         struct params {
             using lhs_rep = typename Lhs::rep;
             using rhs_rep = typename Rhs::rep;
-            using rep_op_result = _impl::op_result<_impl::multiply_op, lhs_rep, rhs_rep>;
+            using rep_op_result = _impl::op_result<_impl::divide_op, lhs_rep, rhs_rep>;
 
             static constexpr int integer_digits =
                     _impl::integer_digits<Lhs>::value + _impl::fractional_digits<Rhs>::value;
@@ -121,7 +121,6 @@ namespace cnl {
             static constexpr int intermediate_exponent_lhs = Lhs::exponent - digits<Rhs>::value;
 
             using result_type = fixed_point<rep_type, rep_exponent>;
-            using intermediate_lhs = fixed_point<rep_type, intermediate_exponent_lhs>;
         };
 
         template<class Lhs, class Rhs>
@@ -132,13 +131,11 @@ namespace cnl {
             constexpr auto operator()(fixed_point<LhsRep, LhsExponent> const& lhs, fixed_point<RhsRep, RhsExponent> const& rhs) const
             -> typename params<fixed_point<LhsRep, LhsExponent>, fixed_point<RhsRep, RhsExponent>>::result_type {
                 using params = params<fixed_point<LhsRep, LhsExponent>, fixed_point<RhsRep, RhsExponent>>;
-                using intermediate_lhs = typename params::intermediate_lhs;
                 using result_type = typename params::result_type;
                 using result_rep = typename result_type::rep;
 
-                return _impl::from_rep<result_type>(
-                        static_cast<result_rep>(_impl::to_rep(static_cast<intermediate_lhs>(lhs))
-                                                / _impl::to_rep(rhs)));
+                return _impl::from_rep<result_type>(static_cast<result_rep>(_impl::scale<digits<RhsRep>::value>(
+                        static_cast<typename params::rep_type>(_impl::to_rep(lhs)))/_impl::to_rep(rhs)));
             }
         };
 

--- a/include/cnl/bits/fixed_point/type.h
+++ b/include/cnl/bits/fixed_point/type.h
@@ -124,13 +124,6 @@ namespace cnl {
         {
         }
 
-        /// copy assignment operator taking an integer type
-        template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy = 0>
-        CNL_COPY_CONSTEXPR fixed_point& operator=(S s)
-        {
-            return operator=(_impl::from_rep<fixed_point<S, 0>>(s));
-        }
-
         /// copy assignment operator taking a floating-point type
         template<class S, _impl::enable_if_t<numeric_limits<S>::is_iec559, int> Dummy = 0>
         CNL_COPY_CONSTEXPR fixed_point& operator=(S s)

--- a/include/cnl/bits/number_base.h
+++ b/include/cnl/bits/number_base.h
@@ -265,13 +265,14 @@ namespace cnl {
     struct from_rep<Derived, constant<Value>, _impl::enable_if_t<_impl::is_derived_from_number_base<Derived>::value>>
     : from_rep<_impl::number_base<Derived, typename Derived::rep>, ::cnl::intmax> {};
 
-    template<class Derived, class Rep>
-    struct scale<_impl::number_base<Derived, Rep>> {
-        template<class Input>
-        constexpr Rep operator()(Input const&i, int base, int exp) const {
-            return (exp < 0)
-                   ? _impl::to_rep(i) / _num_traits_impl::pow<Rep>(base, -exp)
-                   : _impl::to_rep(i) * _num_traits_impl::pow<Rep>(base, exp);
+    template<int Digits, int Radix, class Derived>
+    struct shift<Digits, Radix, _impl::number_base<Derived, typename Derived::rep>> {
+        using _scalar_type = _impl::number_base<Derived, typename Derived::rep>;
+
+        constexpr auto operator()(_scalar_type const &s) const
+        -> decltype(_impl::from_rep<Derived>(_impl::shift<Digits, Radix>(_impl::to_rep(s))))
+        {
+            return _impl::from_rep<Derived>(_impl::shift<Digits, Radix>(_impl::to_rep(s)));
         }
     };
 

--- a/include/cnl/bits/number_base.h
+++ b/include/cnl/bits/number_base.h
@@ -23,7 +23,7 @@ namespace cnl {
 
             number_base() = default;
 
-            constexpr number_base(rep const& r)
+            explicit constexpr number_base(rep const& r)
                 : _rep(r) { }
 
             template<class T>

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -103,7 +103,7 @@ namespace cnl {
     ///
     /// \sa elastic_fixed_point
 
-    template<int Digits, class Narrowest = int>
+    template<int Digits = digits<int>::value, class Narrowest = int>
     class elastic_integer : public _elastic_integer_impl::base_class_t<Digits, Narrowest> {
         static_assert(Digits > 0, "type requires positive number of digits");
         using _base = _elastic_integer_impl::base_class_t<Digits, Narrowest>;

--- a/include/cnl/num_traits.h
+++ b/include/cnl/num_traits.h
@@ -185,6 +185,23 @@ namespace cnl {
     using set_digits_t = typename set_digits<T, Digits>::type;
 
     ////////////////////////////////////////////////////////////////////////////////
+    // cnl::is_integral
+
+    template<class T>
+    struct is_integral : std::is_integral<T> {
+    };
+
+#if defined(CNL_INT128_ENABLED)
+    template<>
+    struct is_integral<int128> : std::integral_constant<bool, true> {
+    };
+
+    template<>
+    struct is_integral<uint128> : std::integral_constant<bool, true> {
+    };
+#endif
+
+    ////////////////////////////////////////////////////////////////////////////////
     // cnl::is_signed
 
     template<class T>

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -165,20 +165,29 @@ namespace cnl {
         using type = overflow_integer<set_digits_t<Rep, MinNumBits>, OverflowTag>;
     };
 
+    template<class FromRep, class OverflowTag, class Rep>
+    struct from_rep<overflow_integer<FromRep, OverflowTag>, Rep> {
+        constexpr auto operator()(Rep const& rep) const
+        -> overflow_integer<Rep, OverflowTag>
+        {
+            return rep;
+        }
+    };
+
     template<class Rep, class OverflowTag, class Value>
     struct from_value<overflow_integer<Rep, OverflowTag>, Value> {
         using type = overflow_integer<Value, OverflowTag>;
     };
 
-    template<class Rep, class OverflowTag>
-    struct scale<overflow_integer<Rep, OverflowTag>> {
-        using value_type = overflow_integer<Rep, OverflowTag>;
-        constexpr auto operator()(value_type const& i, int base, int exp) const
-        -> decltype(_impl::to_rep(i) * _num_traits_impl::pow<value_type>(base, exp)) {
-            return (exp < 0)
-                   ? _impl::to_rep(i) / _num_traits_impl::pow<value_type>(base, -exp)
-                   : _impl::to_rep(i) * _num_traits_impl::pow<value_type>(base, exp);
-        }
+    template<class Rep, class OverflowTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
+    struct from_value<overflow_integer<Rep, OverflowTag>, constant<Value>> {
+        using _rep = typename std::conditional<digits<int>::value<used_bits(Value), decltype(Value), int>::type;
+        using type = overflow_integer<_rep, OverflowTag>;
+    };
+
+    template<int Digits, int Radix, class Rep, class OverflowTag>
+    struct shift<Digits, Radix, overflow_integer<Rep, OverflowTag>>
+            : shift<Digits, Radix, _impl::number_base<overflow_integer<Rep, OverflowTag>, Rep>> {
     };
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -328,7 +337,7 @@ namespace std {
                     cnl::fixed_point<cnl::overflow_integer<RhsRep, RhsOverflowTag>, 0>> {
     };
     
-    // std::common_type<cnl::overflow, cnl::overflow>
+    // std::common_type<cnl::overflow_integer, cnl::overflow_integer>
     template<
             class LhsRep, class LhsOverflowTag,
             class RhsRep, class RhsOverflowTag>

--- a/include/cnl/precise_integer.h
+++ b/include/cnl/precise_integer.h
@@ -11,6 +11,7 @@
 #include "limits.h"
 
 #include "bits/number_base.h"
+#include "numeric.h"
 
 namespace cnl {
 
@@ -57,6 +58,15 @@ namespace cnl {
         using type = precise_integer<set_digits_t<Rep, MinNumBits>, RoundingTag>;
     };
 
+    template<class FromRep, class RoundingTag, class Rep>
+    struct from_rep<precise_integer<FromRep, RoundingTag>, Rep> {
+        constexpr auto operator()(precise_integer<FromRep, RoundingTag> const& rep) const
+        -> precise_integer<Rep, RoundingTag>
+        {
+            return rep;
+        }
+    };
+
     namespace _impl {
         template<class Rep, class RoundingTag>
         struct get_rep<precise_integer<Rep, RoundingTag>> {
@@ -74,9 +84,17 @@ namespace cnl {
         using type = precise_integer<Value, RoundingTag>;
     };
 
-    template<class Rep, class RoundingTag>
-    struct scale<precise_integer<Rep, RoundingTag>>
-    : scale<_impl::number_base<precise_integer<Rep, RoundingTag>, Rep>> {
+    template<class Rep, class RoundingTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
+    struct from_value<precise_integer<Rep, RoundingTag>, constant<Value>> {
+        using _rep = typename std::conditional<digits<int>::value<used_bits(Value),
+                decltype(Value),
+                int>::type;
+        using type = precise_integer<_rep, RoundingTag>;
+    };
+
+    template<int Digits, int Radix, class Rep, class RoundingTag>
+    struct shift<Digits, Radix, precise_integer<Rep, RoundingTag>>
+            : shift<Digits, Radix, _impl::number_base<precise_integer<Rep, RoundingTag>, Rep>> {
     };
 
     namespace _precise_integer_impl {

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -124,9 +124,9 @@ static void bm_sqrt(benchmark::State& state)
 template<class T>
 static void bm_magnitude_squared(benchmark::State& state)
 {
-    auto x = T {1};
-    auto y = T {4};
-    auto z = T {9};
+    auto x = T {1LL};
+    auto y = T {4LL};
+    auto z = T {9LL};
     while (state.KeepRunning()) {
         ESCAPE(x);
         ESCAPE(y);
@@ -139,12 +139,12 @@ static void bm_magnitude_squared(benchmark::State& state)
 template<class T>
 static void bm_circle_intersect_generic(benchmark::State& state)
 {
-    auto x1 = T {0};
-    auto y1 = T {10};
-    auto r1 = T {14};
-    auto x2 = T {4};
-    auto y2 = T {13};
-    auto r2 = T {9};
+    auto x1 = T {0LL};
+    auto y1 = T {10LL};
+    auto r1 = T {14LL};
+    auto x2 = T {4LL};
+    auto y2 = T {13LL};
+    auto r2 = T {9LL};
     while (state.KeepRunning()) {
         ESCAPE(x1);
         ESCAPE(y1);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -172,7 +172,24 @@ set_target_properties(
 
 target_link_libraries(fp_test cnl)
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+    # https://developercommunity.visualstudio.com/content/problem/55671/c4307-issued-for-unsigned.html
+    set_source_files_properties(
+            overflow/overflow.cpp
+            PROPERTIES COMPILE_FLAGS "/wd4307")
+
+    set_source_files_properties(
+            overflow/overflow_int.cpp
+            PROPERTIES COMPILE_FLAGS "/wd4307")
+
+    set_source_files_properties(
+            fixed_point/fixed_point_built_in.cpp
+            PROPERTIES COMPILE_FLAGS "/wd4307")
+
+    set_source_files_properties(
+            fixed_point/overflow_int/fixed_point_native_integer.cpp
+            PROPERTIES COMPILE_FLAGS "/wd4307")
+elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
     set_source_files_properties(
             boost.multiprecision.cpp
             index.cpp
@@ -190,6 +207,10 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL
     set_source_files_properties(
             fixed_point/math.cpp
             PROPERTIES COMPILE_FLAGS "-Wno-integer-overflow")
+
+    set_source_files_properties(
+            fixed_point/fixed_point_built_in.cpp
+            PROPERTIES COMPILE_FLAGS "-Wno-overflow")
 endif ()
 
 ######################################################################

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -179,7 +179,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
             PROPERTIES COMPILE_FLAGS "/wd4307")
 
     set_source_files_properties(
-            overflow/overflow_int.cpp
+            overflow/overflow_integer.cpp
             PROPERTIES COMPILE_FLAGS "/wd4307")
 
     set_source_files_properties(
@@ -187,7 +187,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
             PROPERTIES COMPILE_FLAGS "/wd4307")
 
     set_source_files_properties(
-            fixed_point/overflow_int/fixed_point_native_integer.cpp
+            fixed_point/overflow/fixed_point_native_integer.cpp
             PROPERTIES COMPILE_FLAGS "/wd4307")
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
     set_source_files_properties(

--- a/src/test/boost.multiprecision.cpp
+++ b/src/test/boost.multiprecision.cpp
@@ -10,6 +10,7 @@
 
 #include <cnl/fixed_point.h>
 
+#include <boost/version.hpp>
 #include <gtest/gtest.h>
 
 using cnl::fixed_point;
@@ -182,6 +183,32 @@ static_assert(
 static_assert(
         cnl::digits<signed_multiprecision<24>>::value == 24,
         "cnl::digits<boost::multiprecision::number<>> test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// bitwise shift with boost::multiprecision and cnl::constant
+
+// Boost.Multiprecision in 1.58 known to have constexpr support
+#if (BOOST_VERSION>=105800)
+
+TEST(fixed_point_multiprecision, shift_left_constant)
+{
+    auto lhs = cnl::unsigned_multiprecision<15>{1536};
+    auto rhs = cnl::constant<3>{};
+    auto actual = lhs << rhs;
+    auto expected = cnl::unsigned_multiprecision<15>{1536 << 3};
+    ASSERT_EQ(expected, actual);
+}
+
+TEST(fixed_point_multiprecision, shift_right_constant)
+{
+    auto lhs = cnl::unsigned_multiprecision<15>{1536};
+    auto rhs = cnl::constant<3>{};
+    auto actual = lhs >> rhs;
+    auto expected = cnl::unsigned_multiprecision<15>{1536 >> 3};
+    ASSERT_EQ(expected, actual);
+}
+
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // cnl::used_bits<boost::multiprecision::number<>>

--- a/src/test/boost.simd.cpp
+++ b/src/test/boost.simd.cpp
@@ -79,17 +79,24 @@ namespace {
     TEST(boost_simd, scale) {
         using pack = boost::simd::pack<int, 2>;
         auto input = pack{65535, 0};
-        auto output = cnl::scale<pack>()(input, 2, 5);
-        auto expected = pack{65535*32, 0};
+        auto output = cnl::_impl::scale<5>(input);
+        auto expected = pack{65535<<5, 0};
         ASSERT_TRUE(boost::simd::compare_equal(expected, output));
     }
 
     TEST(boost_simd, shift_left) {
-        using output_type = boost::simd::pack<cnl::int64, 2>;
-        using input_type = boost::simd::pack<cnl::uint16, 2>;
-        auto input = input_type{65535, 0};
-        auto output = cnl::_impl::shift_left<5, output_type>(input);
-        auto expected = output_type{65535*32, 0};
+        using pack = boost::simd::pack<int, 2>;
+        auto input = pack{65535, 0};
+        auto output = cnl::_impl::shift<5>(input);
+        auto expected = pack{65535*32, 0};
+        ASSERT_TRUE(boost::simd::compare_equal(expected, output));
+    }
+
+    TEST(boost_simd, shift_right) {
+        using pack = boost::simd::pack<cnl::int64, 2>;
+        auto input = pack{65535, 0};
+        auto output = cnl::_impl::shift<-5>(input);
+        auto expected = pack{65535>>5, 0};
         ASSERT_TRUE(boost::simd::compare_equal(expected, output));
     }
 

--- a/src/test/elastic/elastic_integer.cpp
+++ b/src/test/elastic/elastic_integer.cpp
@@ -37,11 +37,11 @@ namespace {
     namespace test_impl_from_value {
         using cnl::_impl::from_value;
 
-        static_assert(identical(from_value<elastic_integer<0>>(14_c), elastic_integer<4>{14}),
+        static_assert(identical(from_value<elastic_integer<>>(14_c), elastic_integer<4>{14}),
                 "from_value<elastic_integer> test failed");
-        static_assert(identical(from_value<elastic_integer<0>>(-31_c), elastic_integer<5>{-31}),
+        static_assert(identical(from_value<elastic_integer<>>(-31_c), elastic_integer<5>{-31}),
                 "from_value<elastic_integer> test failed");
-        static_assert(identical(from_value<elastic_integer<0>>(-32_c), elastic_integer<6>{-32}),
+        static_assert(identical(from_value<elastic_integer<>>(-32_c), elastic_integer<6>{-32}),
                 "from_value<elastic_integer> test failed");
 
 #if defined(CNL_INT128_ENABLED)
@@ -244,9 +244,10 @@ namespace {
     }
 
     namespace test_scale {
-        using cnl::_impl::scale;
-
-        static_assert(identical(scale(elastic_integer<6>{55}, 2, 2), elastic_integer<6>{220}), "scale<elastic_integer> test failed");
+#if defined(CNL_INT128_ENABLED)
+        static_assert(identical(cnl::elastic_integer<73>{1024}, cnl::_impl::shift<10>(cnl::elastic_integer<63>{1})), "shift<elastic_integer> test failed");
+#endif
+        static_assert(identical(elastic_integer<8>{220}, cnl::shift<2, 2, elastic_integer<6>>{}(55)), "shift<elastic_integer> test failed");
     }
 
     namespace test_numeric_limits {
@@ -408,6 +409,7 @@ namespace {
                 elastic_integer<20+34, unsigned>{0b11001110101011101001LL << 34},
                 elastic_integer<20, unsigned>{0b11001110101011101001} << 34_c),
                 "shift_left test failed");
+        static_assert(identical(elastic_integer<33>{1LL<<32}, cnl::_impl::shift<32>(elastic_integer<1>{1})), "cnl::_impl::shift<32, elastic_integer<1>>");
     }
 
     namespace test_shift_right {

--- a/src/test/fixed_point/constants.cpp
+++ b/src/test/fixed_point/constants.cpp
@@ -30,8 +30,8 @@ namespace {
     // where greater of inputs is max and lesser is min, returns 1-max/min
     template<class Rep, int Exponent>
     long double get_error(fixed_point<Rep, Exponent> fp_constant, long double ld_constant) {
-        assert(fp_constant > 0);
-        assert(ld_constant > 0);
+        assert(fp_constant > 0.);
+        assert(ld_constant > 0.);
 
         auto ratio = static_cast<long double>(fp_constant) / ld_constant;
         auto error = ((ratio>1)?ratio:(1.L/ratio))-1.L;

--- a/src/test/fixed_point/elastic/elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/elastic_fixed_point.cpp
@@ -338,6 +338,19 @@ TEST(elastic_fixed_point, int_over) {
     EXPECT_EQ(e, q);
 }
 
+TEST(elastic_fixed_point, issue_88)
+{
+    using fix_t = cnl::elastic_fixed_point<30, -16>;
+    fix_t a = 2.0f;
+    fix_t b = 1.0f;
+    fix_t c = 1.0f;
+    EXPECT_EQ(static_cast<float>(a),2.0f);
+    EXPECT_EQ(static_cast<float>(b),1.0f);
+    EXPECT_EQ(static_cast<float>(c),1.0f);
+    fix_t d = c + a*b;
+    EXPECT_EQ(static_cast<float>(d),3.0f);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // test how elastic_fixed_point handles negative values;
 // should pass for all signed specializations

--- a/src/test/fixed_point/elastic/elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/elastic_fixed_point.cpp
@@ -44,12 +44,12 @@ namespace {
             elastic_integer<22, uint8_t>{10000}), "cnl::elastic_integer test failed");
 
     static_assert(identical(
-            elastic_fixed_point<2, 2>{1.5} << 1,
-            elastic_fixed_point<2, 2>{3}), "cnl::elastic_fixed_point test failed");
+            elastic_fixed_point<2, -2>{1.5} << 1,
+            elastic_fixed_point<2, -2>{3}), "cnl::elastic_fixed_point test failed");
 
     static_assert(identical(
-            elastic_fixed_point<2, 2>{1.5} >> 1,
-            elastic_fixed_point<2, 2>{0.75}), "cnl::elastic_fixed_point test failed");
+            elastic_fixed_point<2, -2>{1.5} >> 1,
+            elastic_fixed_point<2, -2>{0.75}), "cnl::elastic_fixed_point test failed");
 }
 
 namespace test_sqrt {

--- a/src/test/fixed_point/elastic/make_elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/make_elastic_fixed_point.cpp
@@ -18,7 +18,7 @@ static constexpr auto int_digits = cnl::numeric_limits<int>::digits;
 
 static_assert(identical(make_elastic_fixed_point(cnl::constant<-1>{}), cnl::elastic_fixed_point<1, 0, int>{-1}),
               "using too many bytes to represent -1");
-static_assert(identical(make_elastic_fixed_point(-1_c), cnl::elastic_fixed_point<1, 0, int>{-1}), "using too many bits to represent -1");
+static_assert(identical(make_elastic_fixed_point(-1_c), cnl::elastic_fixed_point<1, 0, int>{-1}), "make_elastic_fixed_point");
 
 static_assert(identical(make_elastic_fixed_point(123), elastic_fixed_point<int_digits>{123}), "cnl::make_elastic_fixed_point test failed");
 static_assert(

--- a/src/test/fixed_point/extras.cpp
+++ b/src/test/fixed_point/extras.cpp
@@ -55,7 +55,7 @@ static_assert(static_cast<float>(sqrt(fixed_point<cnl::int32, -20>(4.0))) == 2.0
 // std specializations for 128-bit integer facilitate certain 64-bit operations
 
 #if defined(CNL_INT128_ENABLED)
-static_assert((fixed_point<cnl::uint64, -8>(1003006)*fixed_point<cnl::uint64, -8>(7))==7021042, "cnl::fixed_point test failed");
+static_assert((fixed_point<cnl::uint64, -8>(1003006L)*fixed_point<cnl::uint64, -8>(7))==7021042L, "cnl::fixed_point test failed");
 static_assert(static_cast<int>((fixed_point<cnl::uint64, -8>(65535)/fixed_point<cnl::uint64, -8>(256)))==255,
         "cnl::fixed_point test failed");
 static_assert(sqrt(fixed_point<cnl::uint64, 0>(9223372036854775807))==3037000499LL, "cnl::sqrt test failed");

--- a/src/test/fixed_point/fixed_point_common.h
+++ b/src/test/fixed_point/fixed_point_common.h
@@ -54,7 +54,6 @@ using uint128 = cnl::set_digits_t<test_unsigned, 128>;
 template <typename Rep=test_int, int Exponent=0>
 using fixed_point = cnl::fixed_point<Rep, Exponent>;
 
-using cnl::_impl::shift_left;
 using cnl::_impl::fp::type::pow2;
 
 template<class Type, cnl::_digits_type MinNumDigits>
@@ -101,12 +100,19 @@ TEST(TOKENPASTE2(TEST_LABEL, copy_assignment), from_alternative_specialization)
 // compound assignment
 
 namespace test_compound_assignment {
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4018)
+#endif
     TEST(TOKENPASTE2(TEST_LABEL, compound_assignment), add_f_i) {
         auto lhs = fixed_point<uint32, -16>{7};
         auto rhs = uint32{12};
         lhs += rhs;
         ASSERT_EQ(lhs, 19);
     }
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
     TEST(TOKENPASTE2(TEST_LABEL, compound_assignment), add_i_f) {
         auto lhs = int32{7};
@@ -209,61 +215,46 @@ static_assert(identical(uint8(0)+uint8(0), test_int{0}), "incorrect assumption a
 // cnl::_impl
 
 ////////////////////////////////////////////////////////////////////////////////
-// cnl::_impl::fp::type::shift_left positive RHS
+// cnl::_impl::shift positive RHS
 
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable: 4310)
 #endif
 
-static_assert(shift_left<1, int8>(uint8(0))==0, "cnl::shift_left test failed");
-static_assert(shift_left<1, int8>(int8(0))==0, "cnl::shift_left test failed");
+static_assert(cnl::_impl::shift<1>(int8(0))==0, "cnl::_impl::shift test failed");
 
 #if defined(TEST_NATIVE_OVERFLOW)
-static_assert(shift_left<8, uint16>((uint16) 0x1234)==0x3400, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint16>((uint8) 0x1234)==0x3400, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint8>((uint16) 0x1234)==0x0, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint16>((uint16) 0x1234)==0x3400, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint16>((uint8) 0x1234)==0x3400, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint8>((uint16) 0x1234)==0x0, "cnl::shift_left test failed");
+static_assert(cnl::_impl::shift<8>(uint16{0x1234})==0x123400, "cnl::_impl::shift test failed");
+static_assert(cnl::_impl::shift<8>(uint8{0x12})==0x1200, "cnl::_impl::shift test failed");
 #endif
 
 #if defined(TEST_SATURATED_OVERFLOW)
-static_assert(identical(shift_left<8, uint16>((uint16)0x1234), uint16{0xffff}), "cnl::shift_left test failed");
-static_assert(shift_left<8, uint16>((uint8)0x1234) == 0xff00, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint8>((uint16)0x1234) == 0xff, "cnl::shift_left test failed");
+static_assert(identical(cnl::_impl::shift<8, 2, uint16>((uint16)0x1234), uint16{0x1234}<<8), "cnl::_impl::shift test failed");
+static_assert(cnl::_impl::shift<8, 2, uint16>((uint8)0x1234) == 0xff00, "cnl::_impl::shift test failed");
+static_assert(cnl::_impl::shift<8, 2, uint8>(0x34) == test_int{0x3400}, "cnl::_impl::shift test failed");
 #endif
 
-static_assert(shift_left<8, int16>(-123)==-31488, "cnl::shift_left test failed");
-
-#if defined(TEST_SATURATED_OVERFLOW)
-static_assert(shift_left<8, uint16>((uint16)0x1234) == 0xffff, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint16>((uint8)0x1234) == 0xff00, "cnl::shift_left test failed");
-static_assert(shift_left<8, uint8>((uint16)0x1234) == 0xff, "cnl::shift_left test failed");
-#endif
-
-static_assert(shift_left<8, int16>(-123)==-31488, "cnl::shift_left test failed");
+static_assert(cnl::_impl::shift<8, 2, int16>(-123)==-31488, "cnl::_impl::shift test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
-// cnl::_impl::fp::type::shift_left negative RHS
+// cnl::_impl::fp::type::cnl::_impl::shift negative RHS
 
-static_assert(shift_left<-8, uint16>((uint16) 0x1234)==0x12, "cnl::shift_left test failed");
-static_assert(shift_left<-8, uint8>((uint16) 0x1234)==0x12, "cnl::shift_left test failed");
-static_assert(shift_left<-8, int16>(-31488)==-123, "cnl::shift_left test failed");
+static_assert(cnl::_impl::shift<-8, 2, uint16>((uint16) 0x1234)==0x12, "cnl::_impl::shift test failed");
+static_assert(cnl::_impl::shift<-8, 2, int16>(-31488)==-123, "cnl::_impl::shift test failed");
 
 #if !defined(TEST_THROWING_OVERFLOW)
-static_assert(shift_left<-8, uint16>((uint8) 0x1234)==0x0, "cnl::shift_left test failed");
+static_assert(cnl::_impl::shift<-8, 2, uint16>((uint8) 0x1234)==0x0, "cnl::_impl::shift test failed");
 #endif
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
-static_assert(shift_left<-8, uint16>((uint16) 0x1234)==0x12, "cnl::shift_left test failed");
-static_assert(shift_left<-8, uint8>((uint16) 0x1234)==0x12, "cnl::shift_left test failed");
-static_assert(shift_left<-8, int16>(-31488)==-123, "cnl::shift_left test failed");
+static_assert(cnl::_impl::shift<-8, 2, uint16>((uint16) 0x1234)==0x12, "cnl::_impl::shift test failed");
+static_assert(cnl::_impl::shift<-8, 2, int16>(-31488)==-123, "cnl::_impl::shift test failed");
 
 #if !defined(TEST_THROWING_OVERFLOW)
-static_assert(shift_left<-8, uint16>((uint8) 0x34)==0x0, "cnl::shift_left test failed");
+static_assert(cnl::_impl::shift<-8, 2, uint16>((uint8) 0x34)==0x0, "cnl::_impl::shift test failed");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -276,6 +267,23 @@ static_assert(pow2<float, -3>()==.125, "cnl::_impl::fp::type::pow2 test failed")
 static_assert(pow2<double, 7>()==128, "cnl::_impl::fp::type::pow2 test failed");
 static_assert(pow2<long double, 10>()==1024, "cnl::_impl::fp::type::pow2 test failed");
 static_assert(pow2<float, 20>()==1048576, "cnl::_impl::fp::type::pow2 test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// cnl::fixed_point<>::fixed_point
+
+namespace ctor {
+    static_assert(identical(fixed_point<uint64>{123}, fixed_point<uint64>(123)), "fixed_point<>::fixed_point");
+#if defined(CNL_INT128_ENABLED)
+    static_assert(identical(fixed_point<uint128, -16>(fixed_point<uint64>{123}), fixed_point<uint128, -16>(123)), "fixed_point<>::fixed_point");
+#endif
+
+#if !defined(TEST_THROWING_OVERFLOW) && !defined(TEST_SATURATED_OVERFLOW)
+    // the equivalent test in elastic_fixed_point.cpp does not lose information
+    static_assert(identical(uint32{0x00003210U}, uint32(fixed_point<uint64, -16>{0x76543210U})), "fixed_point<>::fixed_point");
+#endif
+
+    static_assert(identical(cnl::_impl::to_rep(fixed_point<int, 2>{4}), 1), "cnl::_impl::to_rep<fixed_point<int, 2>>()");
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // numeric traits
@@ -309,6 +317,8 @@ namespace test_from_rep {
 namespace test_from_value {
     static_assert(identical(cnl::_impl::from_value<fixed_point<int32>>(cnl::constant<369>{}), fixed_point<int>{369}),
             "cnl::_impl::from_value<fixed_point<>>");
+
+    static_assert(identical(fixed_point<int, 2>{4}, cnl::_impl::from_value<fixed_point<>>(cnl::constant<4>{})), "cnl::_impl::from_value<fixed_point<>, cnl::constant<4>>()");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -447,31 +457,31 @@ static_assert(fixed_point<int16, 16>(-6553.)==0, "cnl::fixed_point test failed")
 #endif
 static_assert((fixed_point<int32, 16>(-4294967296l))==-4294967296.f, "cnl::fixed_point test failed");
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert((fixed_point<int64, 16>(-1125895611875328l))==-1125895611875328l, "cnl::fixed_point test failed");
+static_assert((fixed_point<int64, 16>(-0x800000000000LL))==-0x800000000000LL, "cnl::fixed_point test failed");
 #endif
 
 // exponent = 1
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(fixed_point<uint8, 1>(510)==510, "cnl::fixed_point test failed");
-static_assert(fixed_point<uint8, 1>(511)==510, "cnl::fixed_point test failed");
+static_assert(fixed_point<uint8, 1>(10)==10, "cnl::fixed_point test failed");
+static_assert(fixed_point<uint8, 1>(11)==10, "cnl::fixed_point test failed");
 static_assert(fixed_point<int8, 1>(123.5)==122, "cnl::fixed_point test failed");
 
-static_assert(fixed_point<int8, 1>(255)==254, "cnl::fixed_point test failed");
-static_assert(fixed_point<int8, 1>(254)==254, "cnl::fixed_point test failed");
+static_assert(fixed_point<int8, 1>(127)==126, "cnl::fixed_point test failed");
+static_assert(fixed_point<int8, 1>(126)==126, "cnl::fixed_point test failed");
 static_assert(fixed_point<int8, 1>(-5)==-4, "cnl::fixed_point test failed");
 #endif
 
 // conversion between fixed_point specializations
 static_assert(fixed_point<uint8, -4>(fixed_point<int16, -8>(1.5))==1.5, "cnl::fixed_point test failed");
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_NATIVE)
+#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_NATIVE) && !defined(TEST_THROWING_OVERFLOW) && !defined(TEST_SATURATED_OVERFLOW)
 static_assert(fixed_point<uint16, -8>(fixed_point<int8, -4>(3.25))==3.25, "cnl::fixed_point test failed");
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_SATURATED) && !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_THROWING)
 static_assert(fixed_point<uint8, 4>(fixed_point<int16, -4>(768))==768, "cnl::fixed_point test failed");
 #endif
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_SATURATED) && !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_THROWING)
-static_assert(fixed_point<uint64, -48>(fixed_point<uint32, -24>(3.141592654))>3.1415923f,
+static_assert(fixed_point<uint32, -24>(fixed_point<uint64, -48>(3.141592654))>3.1415923f,
         "cnl::fixed_point test failed");
-static_assert(fixed_point<uint64, -48>(fixed_point<uint32, -24>(3.141592654))<3.1415927f,
+static_assert(fixed_point<uint32, -24>(fixed_point<uint64, -48>(3.141592654))<3.1415927f,
         "cnl::fixed_point test failed");
 #endif
 #endif
@@ -561,14 +571,14 @@ static_assert(identical(multiply(fixed_point<uint8, -4>{2}, fixed_point<uint8, -
 ////////////////////////////////////////////////////////////////////////////////
 // cnl::divide
 
-static_assert(identical(divide(fixed_point<int16, -14>{1}, test_int{127}), fixed_point<int64, -45>{1./127}),
+static_assert(identical(divide(fixed_point<test_int, -14>{1}, int16{127}), fixed_point<int64, -29>{1./127}),
         "cnl::divide test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // comparison
 
 // heterogeneous fixed-point to fixed-point comparison
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
+#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS) && !defined(TEST_THROWING_OVERFLOW) && !defined(TEST_SATURATED_OVERFLOW)
 static_assert(fixed_point<uint8, -4>(4.5)==fixed_point<int16, -7>(4.5), "cnl::fixed_point test failed");
 static_assert(!(fixed_point<uint8, -4>(4.5)==fixed_point<int16, -7>(-4.5)), "cnl::fixed_point test failed");
 
@@ -577,18 +587,18 @@ static_assert(!(fixed_point<uint8, -4>(4.5)!=fixed_point<int16, -7>(4.5)), "cnl:
 
 static_assert(fixed_point<uint8, -4>(4.5)<fixed_point<int16, -7>(5.6), "cnl::fixed_point test failed");
 #endif
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
+#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS) && !defined(TEST_THROWING_OVERFLOW)
 static_assert(!(fixed_point<int8, -3>(-4.5)<fixed_point<int16, -7>(-5.6)), "cnl::fixed_point test failed");
 #endif
 
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(fixed_point<uint8, -4>(4.6)>fixed_point<int16, -8>(4.5), "cnl::fixed_point test failed");
+#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS) && !defined(TEST_THROWING_OVERFLOW)
+static_assert(fixed_point<uint8, -4>(4.6)>fixed_point<int16, -8>(.5), "cnl::fixed_point test failed");
 static_assert(!(fixed_point<uint8, -4>(4.6)<fixed_point<int16, -8>(-4.5)), "cnl::fixed_point test failed");
 
 static_assert(fixed_point<uint8, -4>(4.5)<=fixed_point<int16, -8>(4.5), "cnl::fixed_point test failed");
 static_assert(!(fixed_point<uint8, -4>(4.5)<=fixed_point<int16, -8>(-4.5)), "cnl::fixed_point test failed");
 
-static_assert(fixed_point<uint8, -4>(4.5)>=fixed_point<int16, -8>(4.5), "cnl::fixed_point test failed");
+static_assert(fixed_point<uint8, -4>(4.5)>=fixed_point<int16, -8>(.5), "cnl::fixed_point test failed");
 static_assert(fixed_point<uint8, -4>(4.5)>=fixed_point<int16, -8>(-4.5), "cnl::fixed_point test failed");
 static_assert(!(fixed_point<uint8, -4>(4.5)>=fixed_point<int16, -8>(4.6)), "cnl::fixed_point test failed");
 #endif
@@ -715,7 +725,7 @@ static_assert((fixed_point<int8, 1>(-255)/fixed_point<int8, 1>(-8))==31, "cnl::f
 #endif
 
 #if defined(TEST_SATURATED_OVERFLOW) && !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(identical(divide(int32(-999), int32(3)), fixed_point<int64, -31>{-333}), "cnl::fixed_point test failed");
+static_assert(identical(divide(int32(-999), int32(3)), fixed_point<int64, -31>{-333L}), "cnl::fixed_point test failed");
 #endif
 #if ! defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_SATURATED) && ! defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_NATIVE) && ! defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_THROWING)
 static_assert(
@@ -752,12 +762,12 @@ static_assert(
 #if defined(CNL_INT128_ENABLED)
 static_assert(cnl::numeric_limits<uint128>::is_specialized, "");
 static_assert(cnl::numeric_limits<uint128>::is_integer, "");
-static_assert(identical(divide(fixed_point<uint64, 0>{0xFFFFFFFE00000001LL}, fixed_point<uint32, 0>{0xffffffff}),
-        fixed_point<uint128, -32>{0xffffffff}), "cnl::fixed_point test failed");
+static_assert(identical(divide(fixed_point<uint64, 0>{0xFFFFFFFE00000001LL}, fixed_point<uint64, -32>{0xffffffffULL}),
+        fixed_point<uint128, -32>{0xffffffffULL}), "cnl::fixed_point test failed");
 #endif
 #endif
 static_assert(identical(divide(fixed_point<uint32, 0>{0xFFFE0001LL}, fixed_point<uint32, 0>{0xffff}),
-        fixed_point<uint64, -32>{0xffff}), "cnl::fixed_point test failed");
+        fixed_point<uint64, -32>{0xffffLL}), "cnl::fixed_point test failed");
 
 namespace test_bitshift {
     // dynamic
@@ -907,6 +917,8 @@ static_assert(sqrt(fixed_point<int8>(81))==9, "cnl::sqrt test failed");
 
 #if defined(TEST_SATURATED_OVERFLOW) && !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
 static_assert(sqrt(fixed_point<uint8, -1>(4))==2, "cnl::sqrt test failed");
+static_assert(cnl::_impl::to_rep(fixed_point<int8, -2>(9))==36, "cnl::sqrt test failed");
+static_assert(sqrt(fixed_point<int, -2>(9))==3, "cnl::sqrt test failed");
 static_assert(sqrt(fixed_point<int8, -2>(9))==3, "cnl::sqrt test failed");
 #endif
 

--- a/src/test/fixed_point/fixed_point_math_common.h
+++ b/src/test/fixed_point/fixed_point_math_common.h
@@ -23,7 +23,7 @@ TEST(math, FPTESTFORMAT) {
 
     //Test negative integer powers (which are representable in the format)
 #if (FPTESTEXP < 0)
-    for (int i = std::max(-cnl::_impl::fractional_digits<fp>::value, -(cnl::_impl::shift_left<cnl::_impl::integer_digits<fp>::value, int32_t>(1)) + 1); i < std::min(0, cnl::_impl::integer_digits<fp>::value - 1); i++) {
+    for (int i = std::max(-cnl::_impl::fractional_digits<fp>::value, -(cnl::_impl::shift<cnl::_impl::integer_digits<fp>::value, 2, int32_t>(1)) + 1); i < std::min(0, cnl::_impl::integer_digits<fp>::value - 1); i++) {
         fp lhs{ exp2(fp{ i }) };
         EXPECT_EQ(lhs, cnl::_impl::from_rep<fp>(1 << (-fp::exponent + i)))
             << "i = " << i << ", fixed point raw: " << cnl::_impl::to_rep(lhs) << " should be: " << (1 << (-fp::exponent + i))

--- a/src/test/fixed_point/overflow/fixed_point_throwing_integer.cpp
+++ b/src/test/fixed_point/overflow/fixed_point_throwing_integer.cpp
@@ -33,13 +33,13 @@ using test_int = cnl::overflow_integer<>;
 
 TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), shift_right)
 {
-    auto shift_left_fn = shift_left<-8, uint16, uint8>;
+    auto shift_left_fn = cnl::_impl::shift<-8, 2, uint16>;
     ASSERT_THROW(shift_left_fn((uint8) 0x1234), std::overflow_error);
 }
 
 TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), shift_left)
 {
-    auto shift_left_fn = shift_left<-8, uint16, uint8>;
+    auto shift_left_fn = cnl::_impl::shift<-8, 2, uint16>;
     ASSERT_THROW(shift_left_fn((uint8) 0x1234), std::overflow_error);
 }
 

--- a/src/test/num_traits.cpp
+++ b/src/test/num_traits.cpp
@@ -26,35 +26,40 @@ namespace {
                       "cnl::numeric_traits<> test failed");
     }
 
+    namespace test_from_value {
+#if defined(CNL_INT128_ENABLED)
+        static_assert(identical(cnl::from_value_t<cnl::uint128, int>{123}, 123), "cnl::from_value_t<cnl::uint128, int>");
+        static_assert(identical(cnl::_impl::from_value<cnl::uint128>(123), 123), "cnl::_impl::from_value<cnl::uint128>");
+#endif
+        static_assert(identical(cnl::_impl::from_value<cnl::uint8>(123), 123), "cnl::_impl::from_value<cnl::uint8>");
+    }
+
     namespace test_set_digits {
         using cnl::set_digits;
         static_assert(identical(cnl::set_digits<cnl::int32, 32>::type{0}, cnl::int64{0}), "");
     }
 
     namespace test_scale {
-        using cnl::_impl::scale;
+        static_assert(identical(cnl::_impl::shift<15, 2, unsigned>(3), 98304U), "cnl::_impl::shift test failed");
 
-        static_assert(identical(scale<unsigned>(3, 2, 15), 98304U),
-                      "cnl::numeric_traits<> test failed");
+        static_assert(identical(cnl::_impl::shift<8, 2, uint8_t>(0b11110101), 0b1111010100000000), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<4, 2, uint8_t>(0b10110110), 0b101101100000), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<2, 2, uint8_t>(0b00111010), 0b11101000), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<0, 2, uint8_t>(0b11101011), 0b11101011), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<-2, 2, uint8_t>(0b01100100), 0b00011001), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<-4, 2, uint8_t>(0b00111001), 0b00000011), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<-8, 2, uint8_t>(0b10110011), 0), "cnl::_impl::shift test failed");
 
-        static_assert(identical(scale<uint8_t>(0b11110101, 2, 8), 0b1111010100000000), "cnl::scale test failed");
-        static_assert(scale<uint8_t>(0b10110110, 2, 4) == 0b101101100000, "cnl::scale test failed");
-        static_assert(scale<uint8_t>(0b00111010, 2, 2) == 0b11101000, "cnl::scale test failed");
-        static_assert(scale<uint8_t>(0b11101011, 2, 0) == 0b11101011, "cnl::scale test failed");
-        static_assert(scale<uint8_t>(0b01100100, 2, -2) == 0b00011001, "cnl::scale test failed");
-        static_assert(scale<uint8_t>(0b00111001, 2, -4) == 0b00000011, "cnl::scale test failed");
-        static_assert(scale<uint8_t>(0b10110011, 2, -8) == 0, "cnl::scale test failed");
+        static_assert(identical(cnl::_impl::shift<8, 2, int8_t>(-0b1110101), -0b111010100000000), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<4, 2, int8_t>(-0b0110110), -0b01101100000), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<2, 2, int8_t>(+0b0011010), +0b1101000), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<0, 2, int8_t>(-0b1101011), -0b1101011), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<-2, 2, int8_t>(+0b1100100), +0b0011001), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<-4, 2, int8_t>(+0b0111001), +0b0000011), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<-8, 2, int8_t>(-0b0110011), -0b0000000), "cnl::_impl::shift test failed");
 
-        static_assert(scale<int8_t>(-0b1110101, 2, 8) == -0b111010100000000, "cnl::scale test failed");
-        static_assert(scale<int8_t>(-0b0110110, 2, 4) == -0b01101100000, "cnl::scale test failed");
-        static_assert(scale<int8_t>(+0b0011010, 2, 2) == +0b1101000, "cnl::scale test failed");
-        static_assert(scale<int8_t>(-0b1101011, 2, 0) == -0b1101011, "cnl::scale test failed");
-        static_assert(scale<int8_t>(+0b1100100, 2, -2) == +0b0011001, "cnl::scale test failed");
-        static_assert(scale<int8_t>(+0b0111001, 2, -4) == +0b0000011, "cnl::scale test failed");
-        static_assert(scale<int8_t>(-0b0110011, 2, -8) == -0b0000000, "cnl::scale test failed");
-
-        static_assert(scale<int32_t>(1, 2, 30) == 0x40000000, "cnl::scale test failed");
-        static_assert(scale<uint64_t>(1, 2, 4) == 16, "cnl::scale test failed");
+        static_assert(identical(cnl::_impl::shift<30, 2, int32_t>(1), 0x40000000), "cnl::_impl::shift test failed");
+        static_assert(identical(cnl::_impl::shift<4, 2, uint64_t>(1), UINT64_C(16)), "cnl::_impl::shift test failed");
     }
 
     namespace test_is_integer_or_float {

--- a/src/test/overflow/elastic/safe_integer.cpp
+++ b/src/test/overflow/elastic/safe_integer.cpp
@@ -125,6 +125,11 @@ namespace {
         static_assert(leading_bits(cnl::safe_integer<1, throwing_overflow_tag, char>{0}) == 1, "leading_bits(cnl::safe_integer)");
         static_assert(leading_bits(cnl::safe_integer<22, throwing_overflow_tag>{77}) == 15, "leading_bits(cnl::safe_integer)");
     }
+
+    namespace test_shift {
+        static_assert(identical(cnl::safe_integer<3>{2}, cnl::_impl::shift<1>(cnl::safe_integer<2>{1})),
+                "cnl::shift<..., cnl::safe_integer<>>");
+    }
 }
 
 // given a rounding tag, invokes number_test_suite for precise_integers of all built-in types

--- a/src/test/overflow/overflow.cpp
+++ b/src/test/overflow/overflow.cpp
@@ -13,11 +13,6 @@
 
 #include <cnl/overflow.h>
 
-// TODO: remove ASAP
-#if defined(_MSC_VER)
-#pragma warning(disable: 4307)
-#endif
-
 namespace {
     using cnl::_impl::identical;
 

--- a/src/test/overflow/overflow_integer.cpp
+++ b/src/test/overflow/overflow_integer.cpp
@@ -438,9 +438,7 @@ namespace test_make_unsigned {
 namespace test_to_rep {
     using cnl::_impl::to_rep;
 
-    static_assert(identical(
-            to_rep(native_integer<cnl::uint8>{3}) * cnl::_num_traits_impl::pow<native_integer<cnl::uint8>>(2, 3),
-            native_integer<int>{24}), "");
+    static_assert(identical(to_rep(native_integer<cnl::uint8>{3}), cnl::uint8{3}), "");
 }
 
 namespace test_from_rep {
@@ -455,8 +453,8 @@ namespace test_impl_from_rep {
     using cnl::_impl::from_rep;
 
     static_assert(identical(from_rep<native_integer<int>>(746352), native_integer<int>{746352}), "");
-    static_assert(from_rep<native_integer<short>>(1), "");
-    static_assert(from_rep<throwing_integer<short>>(1), "");
+    static_assert(identical(from_rep<native_integer<short>>(1), native_integer<int>{1}), "");
+    static_assert(identical(from_rep<throwing_integer<short>>(1), throwing_integer<int>{1}), "");
 }
 
 namespace test_minus {
@@ -475,27 +473,24 @@ namespace test_shift_left {
 }
 
 namespace test_scale {
-    using cnl::scale;
-
     static_assert(identical(
-            scale<throwing_integer<cnl::int32>>()(throwing_integer<cnl::int32>{1}, 2, 15),
+            cnl::_impl::shift<15>(throwing_integer<cnl::int32>{1}),
             throwing_integer<cnl::int32>{32768}),
                   "scale<overflow_integer<>> test failed");
     static_assert(identical(
-            scale<throwing_integer<cnl::int32>>()(throwing_integer<cnl::uint16>{1}, 2, 15),
+            cnl::_impl::shift<15>(throwing_integer<cnl::int32>{1}),
             throwing_integer<cnl::int32>{32768}),
                   "scale<overflow_integer<>> test failed");
 
     static_assert(identical(
-            scale<saturated_integer<cnl::uint16>>()(saturated_integer<cnl::uint8>{0x1234}, 2, 8),
-            saturated_integer<int>{0xff00}),
-                  "scale<overflow_integer<>> test failed");
-}
-
-namespace test_impl_scale {
-    using cnl::_impl::scale;
-
-    static_assert(identical(scale(native_integer<cnl::uint8>{3}, 2, 4), native_integer<int>{48}),
+            cnl::_impl::from_rep<saturated_integer<cnl::uint16>>(0x1234),
+            saturated_integer<int>{0x1234}),
+            "scale<overflow_integer<>> test failed");
+    static_assert(identical(
+            cnl::_impl::shift<8>(saturated_integer<cnl::uint16>{0x1234}),
+            saturated_integer<int>{0x123400}),
+            "scale<overflow_integer<>> test failed");
+    static_assert(identical(cnl::_impl::shift<4>(native_integer<cnl::uint8>{3}), native_integer<int>{48}),
                   "scale<overflow_integer<>> test failed");
 }
 

--- a/src/test/papers/p0675.cpp
+++ b/src/test/papers/p0675.cpp
@@ -30,6 +30,11 @@ namespace cnl {
     template<class Rep>
     struct numeric_limits<smart_integer<Rep>> : numeric_limits<_impl::number_base<smart_integer<Rep>, Rep>> {};
 
+    template<class Rep, class Value>
+    struct from_value<smart_integer<Rep>, Value> {
+        using type = smart_integer<Value>;
+    };
+
     namespace _impl {
         template<class LhsRep, class RhsRep>
         struct binary_operator<subtract_op, smart_integer<LhsRep>, smart_integer<RhsRep>> {


### PR DESCRIPTION
removes code that puts onus on `fixed_point<>` to avoid overflow

- is the job of `elastic_integer`
- complicates design
- adds a second responsibility to `fixed_point<>`
- can't always succeed anyway
- addresses #88 