### PR TITLE
removes _impl::from_rep

### DIFF
--- a/include/cnl/bits/fixed_point/extras.h
+++ b/include/cnl/bits/fixed_point/extras.h
@@ -109,10 +109,10 @@ namespace cnl {
         using widened_rep = set_digits_t<Rep, digits<Rep>::value*2>;
         return
 #if defined(CNL_EXCEPTIONS_ENABLED)
-                (x<_impl::from_rep<fixed_point<Rep, Exponent>>(0))
+                (x<from_rep<fixed_point<Rep, Exponent>>{}(0))
                 ? throw std::invalid_argument("cannot represent square root of negative value") :
 #endif
-                _impl::from_rep<fixed_point<Rep, Exponent>>(_impl::for_rep<widened_rep>(
+                from_rep<fixed_point<Rep, Exponent>>{}(_impl::for_rep<widened_rep>(
                         _impl::fp::extras::sqrt_solve1(),
                         _impl::scale<-Exponent>(static_cast<widened_rep>(to_rep(x)))));
     }
@@ -205,49 +205,49 @@ namespace cnl {
 
         static constexpr _value_type min() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep{1});
+            return from_rep<_value_type>{}(_rep{1});
         }
 
         static constexpr _value_type max() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep_numeric_limits::max());
+            return from_rep<_value_type>{}(_rep_numeric_limits::max());
         }
 
         static constexpr _value_type lowest() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep_numeric_limits::lowest());
+            return from_rep<_value_type>{}(_rep_numeric_limits::lowest());
         }
 
         static constexpr bool is_integer = false;
 
         static constexpr _value_type epsilon() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep{1});
+            return from_rep<_value_type>{}(_rep{1});
         }
 
         static constexpr _value_type round_error() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep{0});
+            return from_rep<_value_type>{}(_rep{0});
         }
 
         static constexpr _value_type infinity() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep{0});
+            return from_rep<_value_type>{}(_rep{0});
         }
 
         static constexpr _value_type quiet_NaN() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep{0});
+            return from_rep<_value_type>{}(_rep{0});
         }
 
         static constexpr _value_type signaling_NaN() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep{0});
+            return from_rep<_value_type>{}(_rep{0});
         }
 
         static constexpr _value_type denorm_min() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep{1});
+            return from_rep<_value_type>{}(_rep{1});
         }
     };
 }

--- a/include/cnl/bits/fixed_point/math.h
+++ b/include/cnl/bits/fixed_point/math.h
@@ -24,7 +24,7 @@ namespace cnl {
             template<class FixedPoint>
             constexpr FixedPoint rounding_conversion(double d) {
                 using one_longer = fixed_point<set_digits_t<typename FixedPoint::rep, digits<FixedPoint>::value+1>, FixedPoint::exponent-1>;
-                return from_rep<FixedPoint>(static_cast<typename FixedPoint::rep>((to_rep(one_longer{ d }) + 1) >> 1));
+                return from_rep<FixedPoint>{}(static_cast<typename FixedPoint::rep>((to_rep(one_longer{ d }) + 1) >> 1));
             }
 
             template<class FixedPoint>
@@ -90,7 +90,7 @@ namespace cnl {
             template<class Rep, int Exponent, _impl::enable_if_t<(Exponent>=0), int> dummy = 0>
             inline constexpr make_largest_ufraction<fixed_point<Rep, Exponent>> exp2m1_0to1(
                     fixed_point<Rep, Exponent>) {
-                return _impl::from_rep<make_largest_ufraction<fixed_point<Rep, Exponent>>>(
+                return from_rep<make_largest_ufraction<fixed_point<Rep, Exponent>>>{}(
                         0); //Cannot construct from 0, since that would be a shift by more than width of type!
             }
             //for a positive exponent, some work needs to be done
@@ -133,7 +133,7 @@ namespace cnl {
 
         //Calculate the final result by shifting the fractional part around.
         //Remember to add the 1 which is left out to get 1 bit more resolution
-        return _impl::from_rep<out_type>(
+        return from_rep<out_type>{}(
                 floor(x) <= Exponent ?
                     typename im::rep{1}//return immediately if the shift would result in all bits being shifted out
                                      :

--- a/include/cnl/bits/fixed_point/named.h
+++ b/include/cnl/bits/fixed_point/named.h
@@ -121,7 +121,7 @@ namespace cnl {
         using result_type = typename params::result_type;
         using result_rep = typename result_type::rep;
 
-        return _impl::from_rep<result_type>(
+        return from_rep<result_type>{}(
                 static_cast<result_rep>(to_rep(static_cast<intermediate_lhs>(lhs))
                                         * to_rep(static_cast<intermediate_rhs>(rhs))));
     }
@@ -188,7 +188,7 @@ namespace cnl {
                 using result_type = typename params::result_type;
                 using result_rep = typename result_type::rep;
 
-                return _impl::from_rep<result_type>(static_cast<result_rep>(_impl::scale<digits<RhsRep>::value>(
+                return from_rep<result_type>{}(static_cast<result_rep>(_impl::scale<digits<RhsRep>::value>(
                         static_cast<typename params::rep_type>(to_rep(lhs)))/to_rep(rhs)));
             }
         };

--- a/include/cnl/bits/fixed_point/num_traits.h
+++ b/include/cnl/bits/fixed_point/num_traits.h
@@ -42,7 +42,23 @@ namespace cnl {
         using type = fixed_point<set_digits_t<Rep, MinNumBits>, Exponent>;
     };
 
+    /// \brief \ref fixed_point specialization of \ref from_rep
+    /// \headerfile cnl/fixed_point.h
+    ///
+    /// \tparam Exponent the \c Exponent parameter of the generated \ref fixed_point type
+    /// \tparam ArchetypeRep ignored; replaced by \c Rep
+    template<class ArchetypeRep, int Exponent>
+    struct from_rep<fixed_point<ArchetypeRep, Exponent>> {
+        /// \brief generates a \ref fixed_point equivalent to \c r in type and value
+        template<typename Rep>
+        constexpr auto operator()(Rep const& r) const
+        -> fixed_point<Rep, Exponent> {
+            return fixed_point<Rep, Exponent>(r, 0);
+        }
+    };
+
     /// \brief \ref fixed_point overload of \ref to_rep(Number const& number)
+    /// \headerfile cnl/fixed_point.h
     template<class Rep, int Exponent>
     constexpr Rep to_rep(fixed_point<Rep, Exponent> const& number)
     {

--- a/include/cnl/bits/fixed_point/operators.h
+++ b/include/cnl/bits/fixed_point/operators.h
@@ -30,9 +30,9 @@ namespace cnl {
         template<class Operator, class Rep, int Exponent>
         struct unary_operator<Operator, fixed_point<Rep, Exponent>> {
             constexpr auto operator()(fixed_point<Rep, Exponent> const& rhs) const
-            -> decltype(from_rep<fixed_point<decltype(Operator()(to_rep(rhs))), Exponent>>(Operator()(to_rep(rhs))))
+            -> decltype(from_rep<fixed_point<decltype(Operator()(to_rep(rhs))), Exponent>>{}(Operator()(to_rep(rhs))))
             {
-                return from_rep<fixed_point<decltype(Operator()(to_rep(rhs))), Exponent>>(Operator()(to_rep(rhs)));
+                return from_rep<fixed_point<decltype(Operator()(to_rep(rhs))), Exponent>>{}(Operator()(to_rep(rhs)));
             }
         };
 
@@ -71,9 +71,9 @@ namespace cnl {
             constexpr auto operator()(
                     fixed_point<LhsRep, LhsExponent> const& lhs,
                     fixed_point<RhsRep, RhsExponent> const& rhs) const
-            -> decltype(from_rep<fixed_point<decltype(to_rep(lhs)*to_rep(rhs)), LhsExponent+RhsExponent>>(to_rep(lhs)*to_rep(rhs)))
+            -> decltype(from_rep<fixed_point<decltype(to_rep(lhs)*to_rep(rhs)), LhsExponent+RhsExponent>>{}(to_rep(lhs)*to_rep(rhs)))
             {
-                return from_rep<fixed_point<decltype(to_rep(lhs)*to_rep(rhs)), LhsExponent+RhsExponent>>(to_rep(lhs)*to_rep(rhs));
+                return from_rep<fixed_point<decltype(to_rep(lhs)*to_rep(rhs)), LhsExponent+RhsExponent>>{}(to_rep(lhs)*to_rep(rhs));
             }
         };
 
@@ -85,9 +85,11 @@ namespace cnl {
             constexpr auto operator()(
                     fixed_point<LhsRep, LhsExponent> const& lhs,
                     fixed_point<RhsRep, RhsExponent> const& rhs) const
-            -> decltype(from_rep<fixed_point<decltype(to_rep(lhs)/to_rep(rhs)), LhsExponent-RhsExponent>>(to_rep(lhs)/to_rep(rhs)))
+            -> decltype(from_rep<fixed_point<decltype(to_rep(lhs)/to_rep(rhs)), LhsExponent-RhsExponent>>{}(to_rep(lhs)
+                    /to_rep(rhs)))
             {
-                return from_rep<fixed_point<decltype(to_rep(lhs)/to_rep(rhs)), LhsExponent-RhsExponent>>(to_rep(lhs)/to_rep(rhs));
+                return from_rep<fixed_point<decltype(to_rep(lhs)/to_rep(rhs)), LhsExponent-RhsExponent>>{}(to_rep(lhs)
+                        /to_rep(rhs));
             }
         };
 
@@ -99,9 +101,9 @@ namespace cnl {
             constexpr auto operator()(
                     fixed_point<LhsRep, LhsExponent> const& lhs,
                     fixed_point<RhsRep, RhsExponent> const& rhs) const
-            -> decltype(from_rep<fixed_point<decltype(to_rep(lhs)%to_rep(rhs)), LhsExponent>>(to_rep(lhs)%to_rep(rhs)))
+            -> decltype(from_rep<fixed_point<decltype(to_rep(lhs)%to_rep(rhs)), LhsExponent>>{}(to_rep(lhs)%to_rep(rhs)))
             {
-                return from_rep<fixed_point<decltype(to_rep(lhs)%to_rep(rhs)), LhsExponent>>(to_rep(lhs)%to_rep(rhs));
+                return from_rep<fixed_point<decltype(to_rep(lhs)%to_rep(rhs)), LhsExponent>>{}(to_rep(lhs)%to_rep(rhs));
             }
         };
 
@@ -121,9 +123,11 @@ namespace cnl {
                 enable_if_t<is_zero_degree<Operator>::value, typename Operator::is_not_comparison>> {
             constexpr auto operator()(
                     fixed_point<LhsRep, Exponent> const& lhs, fixed_point<RhsRep, Exponent> const& rhs) const
-            -> decltype(from_rep<fixed_point<decltype(Operator()(to_rep(lhs), to_rep(rhs))), Exponent>>(Operator()(to_rep(lhs), to_rep(rhs))))
+            -> decltype(from_rep<fixed_point<decltype(Operator()(to_rep(lhs), to_rep(rhs))), Exponent>>{}(
+                    Operator()(to_rep(lhs), to_rep(rhs))))
             {
-                return from_rep<fixed_point<decltype(Operator()(to_rep(lhs), to_rep(rhs))), Exponent>>(Operator()(to_rep(lhs), to_rep(rhs)));
+                return from_rep<fixed_point<decltype(Operator()(to_rep(lhs), to_rep(rhs))), Exponent>>{}(
+                        Operator()(to_rep(lhs), to_rep(rhs)));
             }
         };
 
@@ -139,15 +143,15 @@ namespace cnl {
             constexpr auto operator()(
                     fixed_point<LhsRep, LhsExponent> const& lhs, fixed_point<RhsRep, RhsExponent> const& rhs) const
             -> decltype(Operator{}(
-                    _impl::from_rep<fixed_point<LhsRep, _common_exponent >> (
+                    from_rep<fixed_point<LhsRep, _common_exponent>>{}(
                             _impl::shift<_lhs_left_shift>(to_rep(lhs))),
-                    _impl::from_rep<fixed_point<RhsRep, _common_exponent >> (
+                    from_rep<fixed_point<RhsRep, _common_exponent>>{}(
                             _impl::shift<_rhs_left_shift>(to_rep(rhs)))))
             {
                 return Operator{}(
-                        _impl::from_rep<fixed_point<LhsRep, _common_exponent>>(
+                        from_rep<fixed_point<LhsRep, _common_exponent>>{}(
                                 _impl::shift<_lhs_left_shift>(to_rep(lhs))),
-                        _impl::from_rep<fixed_point<RhsRep, _common_exponent>>(
+                        from_rep<fixed_point<RhsRep, _common_exponent>>{}(
                                 _impl::shift<_rhs_left_shift>(to_rep(rhs))));
             }
         };
@@ -159,16 +163,16 @@ namespace cnl {
     // fixed_point, dynamic
     template<class LhsRep, int LhsExponent, class Rhs>
     constexpr auto operator<<(fixed_point<LhsRep, LhsExponent> const& lhs, Rhs const& rhs)
-    -> decltype(_impl::from_rep<fixed_point<decltype(to_rep(lhs) << int(rhs)), LhsExponent>>(to_rep(lhs) << int(rhs)))
+    -> decltype(from_rep<fixed_point<decltype(to_rep(lhs) << int(rhs)), LhsExponent>>{}(to_rep(lhs) << int(rhs)))
     {
-        return _impl::from_rep<fixed_point<decltype(to_rep(lhs) << int(rhs)), LhsExponent>>(to_rep(lhs) << int(rhs));
+        return from_rep<fixed_point<decltype(to_rep(lhs) << int(rhs)), LhsExponent>>{}(to_rep(lhs) << int(rhs));
     }
 
     template<class LhsRep, int LhsExponent, class Rhs>
     constexpr auto operator>>(fixed_point<LhsRep, LhsExponent> const& lhs, Rhs const& rhs)
-    -> decltype(_impl::from_rep<fixed_point<decltype(to_rep(lhs) >> int(rhs)), LhsExponent>>(to_rep(lhs) >> int(rhs)))
+    -> decltype(from_rep<fixed_point<decltype(to_rep(lhs) >> int(rhs)), LhsExponent>>{}(to_rep(lhs) >> int(rhs)))
     {
-        return _impl::from_rep<fixed_point<decltype(to_rep(lhs) >> int(rhs)), LhsExponent>>(to_rep(lhs) >> int(rhs));
+        return from_rep<fixed_point<decltype(to_rep(lhs) >> int(rhs)), LhsExponent>>{}(to_rep(lhs) >> int(rhs));
     }
 
     // fixed_point, const_integer
@@ -176,14 +180,14 @@ namespace cnl {
     constexpr fixed_point<LhsRep, LhsExponent+static_cast<int>(RhsValue)>
     operator<<(fixed_point<LhsRep, LhsExponent> const& lhs, constant<RhsValue>)
     {
-        return _impl::from_rep<fixed_point<LhsRep, LhsExponent+static_cast<int>(RhsValue)>>(to_rep(lhs));
+        return from_rep<fixed_point<LhsRep, LhsExponent+static_cast<int>(RhsValue)>>{}(to_rep(lhs));
     }
 
     template<class LhsRep, int LhsExponent, CNL_IMPL_CONSTANT_VALUE_TYPE RhsValue>
     constexpr fixed_point<LhsRep, LhsExponent-static_cast<int>(RhsValue)>
     operator>>(fixed_point<LhsRep, LhsExponent> const& lhs, constant<RhsValue>)
     {
-        return _impl::from_rep<fixed_point<LhsRep, LhsExponent-static_cast<int>(RhsValue)>>(to_rep(lhs));
+        return from_rep<fixed_point<LhsRep, LhsExponent-static_cast<int>(RhsValue)>>{}(to_rep(lhs));
     }
 }
 

--- a/include/cnl/bits/fixed_point/type.h
+++ b/include/cnl/bits/fixed_point/type.h
@@ -126,7 +126,7 @@ namespace cnl {
         /// constructor taking a cnl::constant object
         template<CNL_IMPL_CONSTANT_VALUE_TYPE Value>
         constexpr fixed_point(constant<Value>)
-                : fixed_point(_impl::from_rep<fixed_point<decltype(Value), 0>>(Value))
+                : fixed_point(from_rep<fixed_point<decltype(Value), 0>>{}(Value))
         {
         }
 
@@ -176,7 +176,7 @@ namespace cnl {
         }
 
         /// creates an instance given the underlying representation value
-        template<class, class, class>
+        template<class, class>
         friend struct from_rep;
 
     private:
@@ -287,7 +287,7 @@ namespace cnl {
     template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy>
     constexpr S fixed_point<Rep, Exponent>::one()
     {
-        return _impl::from_rep<fixed_point<S, 0>>(1);
+        return from_rep<fixed_point<S, 0>>{}(1);
     }
 
     template<class Rep, int Exponent>
@@ -316,8 +316,9 @@ namespace cnl {
     ////////////////////////////////////////////////////////////////////////////////
     // cnl::from_rep<fixed_point<>> specialization
 
-    template<class Rep, int Exponent, class Integer>
-    struct from_rep<fixed_point<Rep, Exponent>, Integer> {
+    template<class Rep, int Exponent>
+    struct from_rep<fixed_point<Rep, Exponent>> {
+        template<typename Integer>
         constexpr auto operator()(Integer const& rep) const
         -> fixed_point<Integer, Exponent> {
             return fixed_point<Integer, Exponent>(rep, 0);

--- a/include/cnl/bits/fixed_point/type.h
+++ b/include/cnl/bits/fixed_point/type.h
@@ -312,18 +312,6 @@ namespace cnl {
     {
         return _impl::shift<FromExponent-exponent>(to_rep(rhs));
     }
-
-    ////////////////////////////////////////////////////////////////////////////////
-    // cnl::from_rep<fixed_point<>> specialization
-
-    template<class Rep, int Exponent>
-    struct from_rep<fixed_point<Rep, Exponent>> {
-        template<typename Integer>
-        constexpr auto operator()(Integer const& rep) const
-        -> fixed_point<Integer, Exponent> {
-            return fixed_point<Integer, Exponent>(rep, 0);
-        }
-    };
 }
 
 #endif  // CNL_FIXED_POINT_DEF_H

--- a/include/cnl/bits/number_base.h
+++ b/include/cnl/bits/number_base.h
@@ -213,18 +213,14 @@ namespace cnl {
         }
     }
 
-    template<class Derived, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
-    struct from_rep<Derived, constant<Value>, _impl::enable_if_t<_impl::is_derived_from_number_base<Derived>::value>>
-    : from_rep<_impl::number_base<Derived, typename Derived::rep>, ::cnl::intmax> {};
-
     template<int Digits, int Radix, class Derived>
     struct shift<Digits, Radix, _impl::number_base<Derived, typename Derived::rep>> {
         using _scalar_type = _impl::number_base<Derived, typename Derived::rep>;
 
         constexpr auto operator()(_scalar_type const &s) const
-        -> decltype(_impl::from_rep<Derived>(_impl::shift<Digits, Radix>(to_rep(s))))
+        -> decltype(from_rep<Derived>{}(_impl::shift<Digits, Radix>(to_rep(s))))
         {
-            return _impl::from_rep<Derived>(_impl::shift<Digits, Radix>(to_rep(s)));
+            return from_rep<Derived>{}(_impl::shift<Digits, Radix>(to_rep(s)));
         }
     };
 
@@ -243,22 +239,22 @@ namespace cnl {
 
         static constexpr _value_type min() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep_numeric_limits::min());
+            return from_rep<_value_type>{}(_rep_numeric_limits::min());
         }
 
         static constexpr _value_type max() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep_numeric_limits::max());
+            return from_rep<_value_type>{}(_rep_numeric_limits::max());
         }
 
         static constexpr _value_type lowest() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep_numeric_limits::lowest());
+            return from_rep<_value_type>{}(_rep_numeric_limits::lowest());
         }
 
         static constexpr _value_type epsilon() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep_numeric_limits::round_error());
+            return from_rep<_value_type>{}(_rep_numeric_limits::round_error());
         }
 
         static constexpr _value_type round_error() noexcept

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -90,13 +90,17 @@ namespace cnl {
         };
     }
 
+    /// \brief \ref elastic_integer specialization of \ref from_rep
+    /// \tparam Digits ignored; replaced by number of digits of \c Rep
+    /// \tparam Exponent the \c Exponent parameter of the generated \ref fixed_point type
     template<int Digits, class Narrowest>
     struct from_rep<elastic_integer<Digits, Narrowest>> {
+        /// \brief generates an \ref elastic_integer equivalent to \c r in type and value
         template<typename Rep>
-        constexpr auto operator()(Rep const& rep) const
+        constexpr auto operator()(Rep const& r) const
         -> elastic_integer<Digits, cnl::_impl::make_signed_t<Narrowest, cnl::is_signed<Rep>::value>>
         {
-            return rep;
+            return r;
         }
     };
 

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -90,9 +90,10 @@ namespace cnl {
         };
     }
 
-    template<int Digits, class Narrowest, class Rep>
-    struct from_rep<elastic_integer<Digits, Narrowest>, Rep> {
-        constexpr auto operator()(elastic_integer<Digits, Narrowest> const& rep) const
+    template<int Digits, class Narrowest>
+    struct from_rep<elastic_integer<Digits, Narrowest>> {
+        template<typename Rep>
+        constexpr auto operator()(Rep const& rep) const
         -> elastic_integer<Digits, cnl::_impl::make_signed_t<Narrowest, cnl::is_signed<Rep>::value>>
         {
             return rep;
@@ -275,7 +276,7 @@ namespace cnl {
     {
         using elastic_integer = elastic_integer<RhsDigits, RhsNarrowest>;
         using rep = typename elastic_integer::rep;
-        return _impl::from_rep<elastic_integer>(
+        return from_rep<elastic_integer>{}(
             static_cast<rep>(
                     to_rep(rhs)
                 ^ ((static_cast<rep>(~0)) >> (numeric_limits<rep>::digits - RhsDigits))));
@@ -423,7 +424,7 @@ namespace cnl {
             -> typename operate_params<Operator, LhsDigits, LhsNarrowest, RhsDigits, RhsNarrowest>::result_type
             {
                 using result_type = typename operate_params<Operator, LhsDigits, LhsNarrowest, RhsDigits, RhsNarrowest>::result_type;
-                return from_rep<result_type>(
+                return from_rep<result_type>{}(
                         static_cast<typename result_type::rep>(Operator()(
                                 to_rep(static_cast<result_type>(lhs)),
                                 to_rep(static_cast<result_type>(rhs)))));
@@ -433,34 +434,35 @@ namespace cnl {
 
     template<int LhsDigits, class LhsNarrowest, CNL_IMPL_CONSTANT_VALUE_TYPE RhsValue>
     constexpr auto operator<<(elastic_integer<LhsDigits, LhsNarrowest> const& lhs, constant<RhsValue>)
-    -> decltype(_impl::from_rep<elastic_integer<LhsDigits + static_cast<int>(RhsValue), LhsNarrowest>>(
+    -> decltype(from_rep<elastic_integer<LhsDigits + static_cast<int>(RhsValue), LhsNarrowest>>{}(
             to_rep(static_cast<elastic_integer<LhsDigits + static_cast<int>(RhsValue), LhsNarrowest>>(lhs)) << RhsValue)) {
         using result_type = elastic_integer<LhsDigits + static_cast<int>(RhsValue), LhsNarrowest>;
-        return _impl::from_rep<result_type>(to_rep(static_cast<result_type>(lhs)) << RhsValue);
+        return from_rep<result_type>{}(to_rep(static_cast<result_type>(lhs)) << RhsValue);
     }
 
     template<int LhsDigits, class LhsNarrowest, CNL_IMPL_CONSTANT_VALUE_TYPE RhsValue>
     constexpr auto operator>>(elastic_integer<LhsDigits, LhsNarrowest> const& lhs, constant<RhsValue>)
-    -> decltype (_impl::from_rep<elastic_integer<LhsDigits - static_cast<int>(RhsValue), LhsNarrowest>>(to_rep(lhs) >> RhsValue)) {
-        return _impl::from_rep<elastic_integer<LhsDigits - static_cast<int>(RhsValue), LhsNarrowest>>(to_rep(lhs) >> RhsValue);
+    -> decltype (from_rep<elastic_integer<LhsDigits - static_cast<int>(RhsValue), LhsNarrowest>>{}(to_rep(lhs) >> RhsValue)) {
+        return from_rep<elastic_integer<LhsDigits - static_cast<int>(RhsValue), LhsNarrowest>>{}(to_rep(lhs) >> RhsValue);
     }
 
     // unary operator-
     template<int RhsDigits, class RhsNarrowest>
     constexpr auto operator-(elastic_integer<RhsDigits, RhsNarrowest> const& rhs)
-    -> decltype(_impl::from_rep<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>(-to_rep(static_cast<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>(rhs))))
+    -> decltype(from_rep<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>{}(-to_rep(static_cast<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>(rhs))))
     {
         using result_type = elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>;
-        return _impl::from_rep<result_type>(-to_rep(static_cast<result_type>(rhs)));
+        return from_rep<result_type>{}(-to_rep(static_cast<result_type>(rhs)));
     }
 
     // unary operator+
     template<int RhsDigits, class RhsNarrowest>
     constexpr auto operator+(elastic_integer<RhsDigits, RhsNarrowest> const& rhs)
-    -> decltype(_impl::from_rep<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>(to_rep(static_cast<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>(rhs))))
+    -> decltype(from_rep<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>{}(
+            to_rep(static_cast<elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>>(rhs))))
     {
         using result_type = elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>;
-        return _impl::from_rep<result_type>(to_rep(static_cast<result_type>(rhs)));
+        return from_rep<result_type>{}(to_rep(static_cast<result_type>(rhs)));
     }
 }
 
@@ -531,12 +533,12 @@ namespace cnl {
 
         static constexpr _value_type min() noexcept
         {
-            return _impl::from_rep<_value_type>(1);
+            return from_rep<_value_type>{}(1);
         }
 
         static constexpr _value_type max() noexcept
         {
-            return _impl::from_rep<_value_type>(_rep_max());
+            return from_rep<_value_type>{}(_rep_max());
         }
 
         static constexpr _value_type lowest() noexcept

--- a/include/cnl/num_traits.h
+++ b/include/cnl/num_traits.h
@@ -325,24 +325,17 @@ namespace cnl {
     ////////////////////////////////////////////////////////////////////////////////
     // cnl::from_rep
 
-    template<class Number, class Rep, class Enable = void>
+    template<class Number, class Enable = void>
     struct from_rep;
 
-    template<class Number, class Rep>
-    struct from_rep<Number, Rep, _impl::enable_if_t<cnl::is_integral<Number>::value>> {
+    template<class Number>
+    struct from_rep<Number, _impl::enable_if_t<cnl::is_integral<Number>::value>> {
+        template<class Rep>
         constexpr Number operator()(Rep const& rep) const {
             // by default, a number type's rep type is the number type itself
             return static_cast<Number>(rep);
         }
     };
-
-    namespace _impl {
-        template<class Number, class Rep>
-        constexpr auto from_rep(Rep const& rep)
-        -> decltype(cnl::from_rep<Number, Rep>()(rep)) {
-            return cnl::from_rep<Number, Rep>()(rep);
-        }
-    }
 
     ////////////////////////////////////////////////////////////////////////////////
     // cnl::_impl::for_rep

--- a/include/cnl/num_traits.h
+++ b/include/cnl/num_traits.h
@@ -310,6 +310,7 @@ namespace cnl {
     /// \brief Returns the value encapsulated in \c number
     /// \param number the 'outer' object
     /// \return the 'inner' value
+    /// \sa from_rep, from_value
     template<class Number>
     constexpr Number to_rep(Number const& number) {
         return number;
@@ -325,9 +326,22 @@ namespace cnl {
     ////////////////////////////////////////////////////////////////////////////////
     // cnl::from_rep
 
+    /// \brief generic function object that returns the number encapsulating a given value
+    ///
+    /// \tparam Number archetype for the encapsulating type
+    ///
+    /// \note Rather than returning Number, invocation may return an alternative
+    /// template instantiation based on input parameter.
+    /// \sa to_rep, from_value
     template<class Number, class Enable = void>
     struct from_rep;
 
+    /// \brief Specialization of \ref from_rep for integer types
+    ///
+    /// \tparam Number fundamental integer type to return
+    ///
+    /// \note This specialization *does* return integers of type, \c Number
+    /// \sa to_rep, from_value
     template<class Number>
     struct from_rep<Number, _impl::enable_if_t<cnl::is_integral<Number>::value>> {
         template<class Rep>

--- a/include/cnl/overflow.h
+++ b/include/cnl/overflow.h
@@ -183,7 +183,7 @@ namespace cnl {
                 using result_type = decltype(lhs+rhs);
                 using numeric_limits = numeric_limits<result_type>;
                 return _overflow_impl::return_if(
-                        !((rhs>=_impl::from_rep<Rhs>(0))
+                        !((rhs>=from_rep<Rhs>{}(0))
                           ? (lhs>numeric_limits::max()-rhs)
                           : (lhs<numeric_limits::lowest()-rhs)),
                         lhs+rhs,
@@ -237,7 +237,7 @@ namespace cnl {
                 using result_type = decltype(lhs-rhs);
                 using numeric_limits = numeric_limits<result_type>;
                 return _overflow_impl::return_if(
-                        (rhs<_impl::from_rep<Rhs>(0))
+                        (rhs<from_rep<Rhs>{}(0))
                         ? (lhs<=numeric_limits::max()+rhs)
                         : (lhs>=numeric_limits::lowest()+rhs),
                         lhs-rhs,

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -164,13 +164,17 @@ namespace cnl {
         return to_rep(static_cast<base_type const&>(number));
     }
 
-    template<class FromRep, class OverflowTag>
-    struct from_rep<overflow_integer<FromRep, OverflowTag>> {
+    /// \brief \ref overflow_integer specialization of \ref from_rep
+    /// \tparam ArchetypeRep ignored; replaced by \c Rep
+    /// \tparam OverflowTag the \c OverflowTag of the generated type
+    template<class ArchetypeRep, class OverflowTag>
+    struct from_rep<overflow_integer<ArchetypeRep, OverflowTag>> {
+        /// \brief generates an \ref overflow_integer equivalent to \c r in type and value
         template<typename Rep>
-        constexpr auto operator()(Rep const& rep) const
+        constexpr auto operator()(Rep const& r) const
         -> overflow_integer<Rep, OverflowTag>
         {
-            return rep;
+            return r;
         }
     };
 

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -164,8 +164,9 @@ namespace cnl {
         return to_rep(static_cast<base_type const&>(number));
     }
 
-    template<class FromRep, class OverflowTag, class Rep>
-    struct from_rep<overflow_integer<FromRep, OverflowTag>, Rep> {
+    template<class FromRep, class OverflowTag>
+    struct from_rep<overflow_integer<FromRep, OverflowTag>> {
+        template<typename Rep>
         constexpr auto operator()(Rep const& rep) const
         -> overflow_integer<Rep, OverflowTag>
         {

--- a/include/cnl/rounding_integer.h
+++ b/include/cnl/rounding_integer.h
@@ -80,13 +80,17 @@ namespace cnl {
         using type = rounding_integer<set_digits_t<Rep, MinNumBits>, RoundingTag>;
     };
 
-    template<class FromRep, class RoundingTag>
-    struct from_rep<rounding_integer<FromRep, RoundingTag>> {
+    /// \brief \ref rounding_integer specialization of \ref from_rep
+    /// \tparam ArchetypeRep ignored; replaced by \c Rep
+    /// \tparam RoundingTag the \c RoundingTag of the generated type
+    template<class ArchetypeRep, class RoundingTag>
+    struct from_rep<rounding_integer<ArchetypeRep, RoundingTag>> {
+        /// \brief generates an \ref rounding_integer equivalent to \c r in type and value
         template<typename Rep>
-        constexpr auto operator()(Rep const& rep) const
+        constexpr auto operator()(Rep const& r) const
         -> rounding_integer<Rep, RoundingTag>
         {
-            return rep;
+            return r;
         }
     };
 

--- a/include/cnl/rounding_integer.h
+++ b/include/cnl/rounding_integer.h
@@ -80,9 +80,10 @@ namespace cnl {
         using type = rounding_integer<set_digits_t<Rep, MinNumBits>, RoundingTag>;
     };
 
-    template<class FromRep, class RoundingTag, class Rep>
-    struct from_rep<rounding_integer<FromRep, RoundingTag>, Rep> {
-        constexpr auto operator()(rounding_integer<FromRep, RoundingTag> const& rep) const
+    template<class FromRep, class RoundingTag>
+    struct from_rep<rounding_integer<FromRep, RoundingTag>> {
+        template<typename Rep>
+        constexpr auto operator()(Rep const& rep) const
         -> rounding_integer<Rep, RoundingTag>
         {
             return rep;
@@ -145,10 +146,11 @@ namespace cnl {
         template<class Operator, class Rep, class RoundingTag>
         struct unary_operator<Operator, rounding_integer<Rep, RoundingTag>> {
             constexpr auto operator()(rounding_integer<Rep, RoundingTag> const& operand) const
-            -> decltype(from_rep<rounding_integer<decltype(Operator()(to_rep(operand))), RoundingTag>>(Operator()(to_rep(operand))))
+            -> decltype(from_rep<rounding_integer<decltype(Operator()(to_rep(operand))), RoundingTag>>{}(
+                    Operator()(to_rep(operand))))
             {
                 using result_type = rounding_integer<decltype(Operator()(to_rep(operand))), RoundingTag>;
-                return from_rep<result_type>(Operator()(to_rep(operand)));
+                return from_rep<result_type>{}(Operator()(to_rep(operand)));
             }
         };
     }
@@ -164,10 +166,11 @@ namespace cnl {
             constexpr auto operator()(
                     rounding_integer<LhsRep, RoundingTag> const& lhs,
                     rounding_integer<RhsRep, RoundingTag> const& rhs) const
-            -> decltype(from_rep<rounding_integer<op_result<Operator, LhsRep, RhsRep>, RoundingTag>>(Operator()(to_rep(lhs), to_rep(rhs))))
+            -> decltype(from_rep<rounding_integer<op_result<Operator, LhsRep, RhsRep>, RoundingTag>>{}(
+                    Operator()(to_rep(lhs), to_rep(rhs))))
             {
                 using result_type = rounding_integer<op_result<Operator, LhsRep, RhsRep>, RoundingTag>;
-                return from_rep<result_type>(Operator()(to_rep(lhs), to_rep(rhs)));
+                return from_rep<result_type>{}(Operator()(to_rep(lhs), to_rep(rhs)));
             }
         };
 
@@ -207,11 +210,11 @@ namespace cnl {
     constexpr auto operator<<(
             rounding_integer<LhsRep, LhsRoundingTag> const& lhs,
             RhsInteger const& rhs)
-    -> decltype(_impl::from_rep<rounding_integer<decltype(to_rep(lhs) << rhs), LhsRoundingTag>>(to_rep(lhs) << rhs))
+    -> decltype(from_rep<rounding_integer<decltype(to_rep(lhs) << rhs), LhsRoundingTag>>{}(to_rep(lhs) << rhs))
     {
-        return _impl::from_rep<rounding_integer<
+        return from_rep<rounding_integer<
                 decltype(to_rep(lhs) << rhs),
-                LhsRoundingTag>>(to_rep(lhs) << rhs);
+                LhsRoundingTag>>{}(to_rep(lhs) << rhs);
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/test/fixed_point/elastic/elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/elastic_fixed_point.cpp
@@ -231,7 +231,9 @@ struct positive_elastic_test
     ////////////////////////////////////////////////////////////////////////////////
     // test cnl::numeric_limits<elastic_fixed_point>
 
-    static_assert(min==cnl::_impl::from_rep<elastic_type>(rep{1}), "cnl::numeric_limits test failed");
+#if !defined(_MSC_VER)
+    static_assert(min==cnl::from_rep<elastic_type>{}(rep{1}), "cnl::numeric_limits test failed");
+#endif
     static_assert(!is_less_than(max, min), "cnl::numeric_limits test failed");
     static_assert(is_less_than(zero, min), "cnl::numeric_limits test failed");
     static_assert(!is_less_than(zero, lowest), "cnl::numeric_limits test failed");

--- a/src/test/fixed_point/elastic/elastic_fixed_point.cpp
+++ b/src/test/fixed_point/elastic/elastic_fixed_point.cpp
@@ -322,10 +322,10 @@ struct positive_elastic_test
 #endif
 
     ////////////////////////////////////////////////////////////////////////////////
-    // test cnl::_impl::from_rep
+    // test cnl::from_rep
 
-    static_assert(!cnl::_impl::from_rep<cnl::fixed_point<cnl::elastic_integer<31, unsigned int>, -33>>(0),
-            "cnl::_impl::from_rep<fixed_point<elastic_integer>>(int)");
+    static_assert(!cnl::from_rep<cnl::fixed_point<cnl::elastic_integer<31, unsigned int>, -33>>{}(0),
+            "cnl::from_rep<fixed_point<elastic_integer>>(int)");
 };
 
 TEST(elastic_fixed_point, over_int) {

--- a/src/test/fixed_point/fixed_point_common.h
+++ b/src/test/fixed_point/fixed_point_common.h
@@ -300,15 +300,13 @@ namespace test_to_rep {
 }
 
 namespace test_from_rep {
-    using cnl::_impl::from_rep;
-
-    static_assert(! cnl::from_rep<cnl::fixed_point<unsigned int, -33>, int>()(0), "from_rep");
-    static_assert(identical(from_rep<fixed_point<>>(test_int{0}), fixed_point<>{0}), "from_rep");
-    static_assert(identical(from_rep<fixed_point<int16, -10>>(int16{3072}), fixed_point<int16, -10>{test_int{3}}), "from_rep");
-    static_assert(!from_rep<fixed_point<test_int, -100>>(test_int{0}), "from_rep");
-    static_assert(from_rep<fixed_point<test_int, -100>>(test_int{1}), "from_rep");
-    static_assert(!from_rep<fixed_point<test_int, 1000>>(test_int{0}), "from_rep");
-    static_assert(from_rep<fixed_point<test_int, 1000>>(test_int{1}), "from_rep");
+    static_assert(! cnl::from_rep<cnl::fixed_point<unsigned int, -33>>{}(0), "from_rep");
+    static_assert(identical(cnl::from_rep<fixed_point<>>{}(test_int{0}), fixed_point<>{0}), "from_rep");
+    static_assert(identical(cnl::from_rep<fixed_point<int16, -10>>{}(int16{3072}), fixed_point<int16, -10>{test_int{3}}), "from_rep");
+    static_assert(!cnl::from_rep<fixed_point<test_int, -100>>{}(test_int{0}), "from_rep");
+    static_assert(cnl::from_rep<fixed_point<test_int, -100>>{}(test_int{1}), "from_rep");
+    static_assert(!cnl::from_rep<fixed_point<test_int, 1000>>{}(test_int{0}), "from_rep");
+    static_assert(cnl::from_rep<fixed_point<test_int, 1000>>{}(test_int{1}), "from_rep");
 }
 
 namespace test_from_value {
@@ -976,7 +974,7 @@ struct FixedPointTesterOutsize {
 
     // simply assignment to and from underlying representation
     using numeric_limits = cnl::numeric_limits<fixed_point>;
-    static constexpr fixed_point min = cnl::_impl::from_rep<fixed_point>(rep(1));
+    static constexpr fixed_point min = cnl::from_rep<fixed_point>{}(rep(1));
     static_assert(to_rep(min) == rep(1), "all Rep types should be able to store the number 1!");
 
     // unary common_type_t

--- a/src/test/fixed_point/fixed_point_math_common.h
+++ b/src/test/fixed_point/fixed_point_math_common.h
@@ -25,7 +25,7 @@ TEST(math, FPTESTFORMAT) {
 #if (FPTESTEXP < 0)
     for (int i = std::max(-cnl::_impl::fractional_digits<fp>::value, -(cnl::_impl::shift<cnl::_impl::integer_digits<fp>::value, 2, int32_t>(1)) + 1); i < std::min(0, cnl::_impl::integer_digits<fp>::value - 1); i++) {
         fp lhs{ exp2(fp{ i }) };
-        EXPECT_EQ(lhs, cnl::_impl::from_rep<fp>(1 << (-fp::exponent + i)))
+        EXPECT_EQ(lhs, cnl::from_rep<fp>{}(1 << (-fp::exponent + i)))
             << "i = " << i << ", fixed point raw: " << to_rep(lhs) << " should be: " << (1 << (-fp::exponent + i))
             ;
     }
@@ -70,11 +70,11 @@ TEST(math, FPTESTFORMAT) {
     if (numeric_limits::max() >= int(cnl::_impl::integer_digits<fp>::value)
             && numeric_limits::lowest() <= -cnl::_impl::fractional_digits<fp>::value) {
         //the largest exponent which's result doesn't overflow
-        auto maximum = cnl::_impl::from_rep<fp>(to_rep(fp{cnl::_impl::integer_digits<fp>::value})-1);
+        auto maximum = cnl::from_rep<fp>{}(to_rep(fp{cnl::_impl::integer_digits<fp>::value})-1);
 
         //The next-to-smallest exponent whose result doesn't overflow
         //(The very smallest was already tested with the integer exponents)
-        auto minimum = cnl::_impl::from_rep<fp>(to_rep(fp{-cnl::_impl::fractional_digits<fp>::value})+1);
+        auto minimum = cnl::from_rep<fp>{}(to_rep(fp{-cnl::_impl::fractional_digits<fp>::value})+1);
 
         double doublerep{ maximum };
         double doublerepmini{ minimum };

--- a/src/test/fixed_point/p0037.cpp
+++ b/src/test/fixed_point/p0037.cpp
@@ -32,7 +32,7 @@ namespace design_decisions {
         using cnl::fixed_point;
         using cnl::from_rep;
 
-        constexpr auto a = from_rep<fixed_point<int, -8>, int>()(320);
+        constexpr auto a = from_rep<fixed_point<int, -8>>()(320);
         static_assert(a == 1.25);
 
         constexpr auto b = to_rep(a);

--- a/src/test/fixed_point/rounding_fixed_point.cpp
+++ b/src/test/fixed_point/rounding_fixed_point.cpp
@@ -23,6 +23,6 @@ namespace {
         static_assert(identical(
                 to_rep(rounding_fixed_point<>(-8)),
                 rounding_integer<>(-8)), "rounding_fixed_point ctor test failed");
-        static_assert(rounding_fixed_point<>(0) == cnl::_impl::from_rep<rounding_fixed_point<>>(0), "rounding_fixed_point ctor test failed");
+        static_assert(rounding_fixed_point<>(0) == cnl::from_rep<rounding_fixed_point<>>{}(0), "rounding_fixed_point ctor test failed");
     }
 }

--- a/src/test/number_test.h
+++ b/src/test/number_test.h
@@ -54,7 +54,7 @@ struct number_test {
     using value_type = Number;
     using numeric_limits = cnl::numeric_limits<value_type>;
 
-    static constexpr value_type zero = cnl::_impl::from_rep<value_type>(0);
+    static constexpr value_type zero = cnl::from_rep<value_type>{}(0);
 #if defined(_MSC_VER)
     static constexpr value_type negative_zero{ zero };
 #else
@@ -140,13 +140,13 @@ struct number_test {
     // would not pass for boost.multiprecision
     static_assert(cnl::is_composite<value_type>::value != std::is_fundamental<value_type>::value, "is_composite test failed");
 
-    static constexpr auto lowest_from_rep = cnl::_impl::from_rep<value_type>(cnl::to_rep(lowest));
+    static constexpr auto lowest_from_rep = cnl::from_rep<value_type>{}(cnl::to_rep(lowest));
     static_assert(identical(lowest_from_rep, lowest), "cnl::to_rep & from_rep test failed");
 
-    static constexpr auto zero_from_rep = cnl::_impl::from_rep<value_type>(cnl::to_rep(zero));
+    static constexpr auto zero_from_rep = cnl::from_rep<value_type>{}(cnl::to_rep(zero));
     static_assert(identical(zero_from_rep, zero), "cnl::to_rep & from_rep test failed");
 
-    static constexpr auto max_from_rep = cnl::_impl::from_rep<value_type>(cnl::to_rep(max));
+    static constexpr auto max_from_rep = cnl::from_rep<value_type>{}(cnl::to_rep(max));
     static_assert(identical(max_from_rep, max), "cnl::to_rep & from_rep test failed");
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/test/overflow/overflow_integer.cpp
+++ b/src/test/overflow/overflow_integer.cpp
@@ -441,17 +441,16 @@ namespace test_to_rep {
 namespace test_from_rep {
     using cnl::from_rep;
 
-    static_assert(identical(from_rep<native_integer<int>, int>()(746352), native_integer<int>{746352}), "");
-    static_assert(from_rep<native_integer<short>, short>()(1), "");
-    static_assert(from_rep<throwing_integer<short>, short>()(1), "");
+    static_assert(identical(from_rep<native_integer<int>>()(746352), native_integer<int>{746352}), "");
+    static_assert(from_rep<native_integer<short>>()(short{1}), "");
+    static_assert(from_rep<throwing_integer<short>>()(short{1}), "");
 }
 
 namespace test_impl_from_rep {
-    using cnl::_impl::from_rep;
 
-    static_assert(identical(from_rep<native_integer<int>>(746352), native_integer<int>{746352}), "");
-    static_assert(identical(from_rep<native_integer<short>>(1), native_integer<int>{1}), "");
-    static_assert(identical(from_rep<throwing_integer<short>>(1), throwing_integer<int>{1}), "");
+    static_assert(identical(cnl::from_rep<native_integer<int>>{}(746352), native_integer<int>{746352}), "");
+    static_assert(identical(cnl::from_rep<native_integer<short>>{}(1), native_integer<int>{1}), "");
+    static_assert(identical(cnl::from_rep<throwing_integer<short>>{}(1), throwing_integer<int>{1}), "");
 }
 
 namespace test_from_value {
@@ -492,7 +491,7 @@ namespace test_scale {
                   "scale<overflow_integer<>> test failed");
 
     static_assert(identical(
-            cnl::_impl::from_rep<saturated_integer<cnl::uint16>>(0x1234),
+            cnl::from_rep<saturated_integer<cnl::uint16>>{}(0x1234),
             saturated_integer<int>{0x1234}),
             "scale<overflow_integer<>> test failed");
     static_assert(identical(

--- a/src/test/papers/p0675.cpp
+++ b/src/test/papers/p0675.cpp
@@ -103,7 +103,7 @@ namespace {
 
     TEST(P0675, compose_from_components) {
         auto num = fixed_point<rounded_integer<uint8_t>, -4>{15.9375};
-        ASSERT_TRUE(cnl::_impl::from_rep<decltype(num)>(1) == 1. / 16);
+        ASSERT_TRUE(cnl::from_rep<decltype(num)>{}(1) == 1. / 16);
     }
 
     TEST(P0675, smart_multiply) {
@@ -142,8 +142,8 @@ namespace {
 
         // from_rep
         using cnl::from_rep;
-        static_assert(identical(7, from_rep<int, int>()(7)));
-        static_assert(identical(fixed_point<int, -1>{49.5}, from_rep<fixed_point<int, -1>, int>()(99)));
+        static_assert(identical(7, from_rep<int>{}(7)));
+        static_assert(identical(fixed_point<int, -1>{49.5}, from_rep<fixed_point<int, -1>>{}(99)));
 
         // from_value
         using cnl::from_value_t;

--- a/src/test/rounding/rounding_integer.cpp
+++ b/src/test/rounding/rounding_integer.cpp
@@ -73,10 +73,8 @@ namespace {
         }
 
         namespace test_from_rep {
-            using cnl::_impl::from_rep;
-
             static_assert(
-                    identical(rounding_integer<>{2468}, from_rep<rounding_integer<>>(2468)),
+                    identical(rounding_integer<>{2468}, cnl::from_rep<rounding_integer<>>{}(2468)),
                     "cnl::from_rep<rounding_integer> test failed");
         }
 
@@ -276,8 +274,8 @@ namespace {
 template<class RoundingInteger>
 struct rounding_integer_tests {
     // from_rep
-    static_assert(identical(rounding_integer<>{123}, cnl::_impl::from_rep<rounding_integer<>>(123)),
-                  "cnl::_impl::from_rep<rounding_integer<>> test failed");
+    static_assert(identical(rounding_integer<>{123}, cnl::from_rep<rounding_integer<>>{}(123)),
+                  "cnl::from_rep<rounding_integer<>> test failed");
 
     // to_rep
     static_assert(identical(123, cnl::to_rep(123)), "cnl::to_rep test failed");


### PR DESCRIPTION
- changes signature of cnl::from_rep
  - second parameter moved to cnl::from_rep::operator()