### PR TITLE
Fix install path

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -42,6 +42,6 @@ target_sources(cnl INTERFACE ${cnl_public_headers} ${cnl_implementation_headers}
 target_include_directories(cnl INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 install(
-        DIRECTORY include/cnl
+        DIRECTORY cnl
         DESTINATION include
 )


### PR DESCRIPTION
When I run "make install" with the previous CMakeLists.txt in the develop branch I get:

"""
    Install the project...
    -- Install configuration: ""
    CMake Error at include/cmake_install.cmake:36 (file):
      file INSTALL cannot find
      "~/Projects/cnl/include/include/cnl".
    Call Stack (most recent call first):
      cmake_install.cmake:37 (include)
    

    Makefile:61: recipe for target 'install' failed
    make: *** [install] Error 1
"""

Based on the documentation (https://cmake.org/cmake/help/v3.0/command/install.html), it appears it should be  "cnl", not "include/cnl".  I'm running cmake version 3.5.1
