### PR TITLE
Rounding elastic number

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -39,6 +39,7 @@ set(test_sources
         overflow/elastic/safe_integer.cpp
         fixed_point/elastic/make_elastic_number.cpp
         fixed_point/elastic/elastic_number.cpp
+        fixed_point/elastic/rounding/rounding_elastic_number.cpp
         static_integer.cpp
         static_number.cpp
 )

--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -26,7 +26,7 @@ namespace {
     namespace test_addition_larger {
         static constexpr auto lhs = rounding_elastic_number<32>{1};
         static constexpr auto rhs = rounding_elastic_number<32, -30>{1};
-        static constexpr auto expected = rounding_elastic_number<63, -30>{2};
+        static constexpr auto expected = rounding_elastic_number<63, -30>{2LL};
         static constexpr auto sum = lhs + rhs;
         static_assert(identical(expected, sum), "larger rounding_elastic_number addition");
     }
@@ -35,37 +35,25 @@ namespace {
 
         static_assert(identical(
                 rounding_elastic_number<16, -8>{.5},
-                cnl::divide<cnl::nearest_rounding_tag,
-                        rounding_elastic_number<8, 0>,
-                        rounding_elastic_number<8, 0> >()(rounding_elastic_number<8, 0>{1},
-                                                          rounding_elastic_number<8, 0>{2})),
-                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+                cnl::quotient(rounding_elastic_number<8, 0>{1}, rounding_elastic_number<8, 0>{2})),
+                      "cnl::quotient(rounding_elastic_number, rounding_elastic_number)");
 
         static_assert(identical(
                 rounding_elastic_number<62, -31>{2.},
-                cnl::divide<cnl::nearest_rounding_tag,
-                        rounding_elastic_number<31, 0>,
-                        rounding_elastic_number<31, 0> >()(rounding_elastic_number<31, 0>{2},
-                                                           rounding_elastic_number<31, 0>{1})),
-                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+                cnl::quotient(rounding_elastic_number<31, 0>{2}, rounding_elastic_number<31, 0>{1})),
+                      "cnl::quotient(rounding_elastic_number, rounding_elastic_number)");
 
 #if defined(CNL_INT128_ENABLED)
         static_assert(identical(
                 rounding_elastic_number<96, -48>{2.},
-                cnl::divide<cnl::nearest_rounding_tag,
-                        rounding_elastic_number<48, 0>,
-                        rounding_elastic_number<48, 0> >()(rounding_elastic_number<48, 0>{2},
-                                                           rounding_elastic_number<48, 0>{1})),
-                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+                cnl::quotient(rounding_elastic_number<48, 0>{2}, rounding_elastic_number<48, 0>{1})),
+                          "cnl::quotient(rounding_elastic_number, rounding_elastic_number)");
 #endif
 
         static_assert(identical(
                 rounding_elastic_number<16, -8>{.5},
-                cnl::divide<cnl::nearest_rounding_tag,
-                        rounding_elastic_number<8, -4>,
-                        rounding_elastic_number<8, -4> >()(rounding_elastic_number<8, -4>{1},
-                                                           rounding_elastic_number<8, -4>{2})),
-                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+                cnl::quotient(rounding_elastic_number<8, -4>{1}, rounding_elastic_number<8, -4>{2})),
+                      "cnl::quotient(rounding_elastic_number, rounding_elastic_number)");
 
         static_assert(identical(
                 rounding_elastic_number<16, -8>{.5},

--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -1,3 +1,9 @@
+
+//          Copyright Heikki Berg 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
 #include <cnl.h>
 
 namespace {

--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -1,95 +1,96 @@
 #include <cnl.h>
 
-namespace
-{
+namespace {
 
-template<
-    int IntegerDigits,
-    class RoundingTag = cnl::nearest_rounding_tag,
-    class Narrowest = int>
-using rounding_elastic_integer = cnl::rounding_integer<
-    cnl::elastic_integer<
-        IntegerDigits,
-        Narrowest>,
-    RoundingTag>;
+    template<
+            int IntegerDigits,
+            class RoundingTag = cnl::nearest_rounding_tag,
+            class Narrowest = int>
+    using rounding_elastic_integer = cnl::rounding_integer<
+            cnl::elastic_integer<
+                    IntegerDigits,
+                    Narrowest>,
+            RoundingTag>;
 
-template<int Digits, int Exponent = 0, class RoundingTag = cnl::nearest_rounding_tag, class Narrowest = signed>
-using rounding_elastic_number = cnl::fixed_point<rounding_elastic_integer<Digits, RoundingTag, Narrowest>, Exponent>;
+    template<int Digits, int Exponent = 0, class RoundingTag = cnl::nearest_rounding_tag, class Narrowest = signed>
+    using rounding_elastic_number = cnl::fixed_point<rounding_elastic_integer<Digits, RoundingTag, Narrowest>, Exponent>;
 
-namespace test_addition
-{
-static constexpr auto lhs = rounding_elastic_number<16>{1};
-static constexpr auto rhs = rounding_elastic_number<16, -8>{1};
-static constexpr auto expected = rounding_elastic_number<25, -8>{2};
-static constexpr auto sum = lhs + rhs;
-static_assert(identical(expected, sum), "rounding_elastic_number addition");
-}
+    namespace test_addition {
+        static constexpr auto lhs = rounding_elastic_number<16>{1};
+        static constexpr auto rhs = rounding_elastic_number<16, -8>{1};
+        static constexpr auto expected = rounding_elastic_number<25, -8>{2};
+        static constexpr auto sum = lhs + rhs;
+        static_assert(identical(expected, sum), "rounding_elastic_number addition");
+    }
 
-namespace test_addition_larger {
-static constexpr auto lhs = rounding_elastic_number<32>{1};
-static constexpr auto rhs = rounding_elastic_number<32, -30>{1};
-static constexpr auto expected = rounding_elastic_number<63, -30>{2};
-static constexpr auto sum = lhs + rhs;
-static_assert(identical(expected, sum), "larger rounding_elastic_number addition");
-}
+    namespace test_addition_larger {
+        static constexpr auto lhs = rounding_elastic_number<32>{1};
+        static constexpr auto rhs = rounding_elastic_number<32, -30>{1};
+        static constexpr auto expected = rounding_elastic_number<63, -30>{2};
+        static constexpr auto sum = lhs + rhs;
+        static_assert(identical(expected, sum), "larger rounding_elastic_number addition");
+    }
 
-namespace test_division
-{
+    namespace test_division {
 
-static_assert(identical(
-    rounding_elastic_number<16, -8>{.5},
-    cnl::divide<cnl::nearest_rounding_tag,
-        rounding_elastic_number<8, 0>,
-        rounding_elastic_number<8, 0> >()(rounding_elastic_number<8, 0>{1},
-                                          rounding_elastic_number<8, 0>{2})),
-              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+        static_assert(identical(
+                rounding_elastic_number<16, -8>{.5},
+                cnl::divide<cnl::nearest_rounding_tag,
+                        rounding_elastic_number<8, 0>,
+                        rounding_elastic_number<8, 0> >()(rounding_elastic_number<8, 0>{1},
+                                                          rounding_elastic_number<8, 0>{2})),
+                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
 
-static_assert(identical(
-    rounding_elastic_number<62, -31>{2.},
-    cnl::divide<cnl::nearest_rounding_tag,
-        rounding_elastic_number<31, 0>,
-        rounding_elastic_number<31, 0> >()(rounding_elastic_number<31, 0>{2},
-                                           rounding_elastic_number<31, 0>{1})),
-              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+        static_assert(identical(
+                rounding_elastic_number<62, -31>{2.},
+                cnl::divide<cnl::nearest_rounding_tag,
+                        rounding_elastic_number<31, 0>,
+                        rounding_elastic_number<31, 0> >()(rounding_elastic_number<31, 0>{2},
+                                                           rounding_elastic_number<31, 0>{1})),
+                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
 
 #if defined(CNL_INT128_ENABLED)
-static_assert(identical(
-    rounding_elastic_number<96, -48>{2.},
-    cnl::divide<cnl::nearest_rounding_tag,
-        rounding_elastic_number<48, 0>,
-        rounding_elastic_number<48, 0> >()(rounding_elastic_number<48, 0>{2},
-                                           rounding_elastic_number<48, 0>{1})),
-              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+        static_assert(identical(
+                rounding_elastic_number<96, -48>{2.},
+                cnl::divide<cnl::nearest_rounding_tag,
+                        rounding_elastic_number<48, 0>,
+                        rounding_elastic_number<48, 0> >()(rounding_elastic_number<48, 0>{2},
+                                                           rounding_elastic_number<48, 0>{1})),
+                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
 #endif
 
-static_assert(identical(
-    rounding_elastic_number<16, -8>{.5},
-    cnl::divide<cnl::nearest_rounding_tag,
-        rounding_elastic_number<8, -4>,
-        rounding_elastic_number<8,-4> >()(rounding_elastic_number<8, -4>{1},
-                                           rounding_elastic_number<8, -4>{2})),
-              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+        static_assert(identical(
+                rounding_elastic_number<16, -8>{.5},
+                cnl::divide<cnl::nearest_rounding_tag,
+                        rounding_elastic_number<8, -4>,
+                        rounding_elastic_number<8, -4> >()(rounding_elastic_number<8, -4>{1},
+                                                           rounding_elastic_number<8, -4>{2})),
+                      "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
 
- static_assert(identical(
-    rounding_elastic_number<16, -8>{.5},
-    make_fixed_point(cnl::make_fractional(rounding_elastic_number<8, 0>{1}, rounding_elastic_number<8, 0>{2}))),
-              "cnl::rounding_elastic_number division");
+        static_assert(identical(
+                rounding_elastic_number<16, -8>{.5},
+                make_fixed_point(cnl::make_fractional(
+                        rounding_elastic_number<8, 0>{1},
+                        rounding_elastic_number<8, 0>{2}))), "cnl::rounding_elastic_number division");
 
-static_assert(identical(
-    rounding_elastic_number<62, -31>{.5},
-    make_fixed_point(cnl::make_fractional(rounding_elastic_number<31, 0>{1}, rounding_elastic_number<31, 0>{2}))),
-              "cnl::rounding_elastic_number division");
+        static_assert(identical(
+                rounding_elastic_number<62, -31>{.5},
+                make_fixed_point(cnl::make_fractional(
+                        rounding_elastic_number<31, 0>{1},
+                        rounding_elastic_number<31, 0>{2}))), "cnl::rounding_elastic_number division");
 
 #if defined(CNL_INT128_ENABLED)
-static_assert(identical(
-    rounding_elastic_number<96, -48>{.5},
-    make_fixed_point(cnl::make_fractional(rounding_elastic_number<48, 0>{1}, rounding_elastic_number<48, 0>{2}))),
-              "cnl::rounding_elastic_number division");
+        static_assert(identical(
+                rounding_elastic_number<96, -48>{.5},
+                make_fixed_point(cnl::make_fractional(
+                        rounding_elastic_number<48, 0>{1},
+                        rounding_elastic_number<48, 0>{2}))), "cnl::rounding_elastic_number division");
 
-static_assert(identical(
-            rounding_elastic_number<124, -62>{.5},
-            make_fixed_point(cnl::make_fractional(rounding_elastic_number<62, 0>{1}, rounding_elastic_number<62, 0>{2}))),
-            "cnl::rounding_elastic_number division");
+        static_assert(identical(
+                rounding_elastic_number<124, -62>{.5},
+                make_fixed_point(cnl::make_fractional(
+                        rounding_elastic_number<62, 0>{1},
+                        rounding_elastic_number<62, 0>{2}))), "cnl::rounding_elastic_number division");
 #endif
-}
+    }
 }

--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -37,6 +37,14 @@ namespace {
         static_assert(identical(expected, sum), "larger rounding_elastic_number addition");
     }
 
+    namespace test_shift {
+        static constexpr auto a = rounding_elastic_number<16, -8>{1};
+        static_assert(identical(rounding_elastic_number<16, -8>{2}, a << 1), "rounding_elastic_number shift");
+        static_assert(identical(rounding_elastic_number<16, -8>{.5}, a >> 1), "rounding_elastic_number shift");
+        static_assert(identical(rounding_elastic_number<16, -8>{1}, a << 0), "rounding_elastic_number shift");
+        static_assert(identical(rounding_elastic_number<16, -8>{1}, a >> 0), "rounding_elastic_number shift");
+    }
+
     namespace test_division {
 
         static_assert(identical(

--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -1,0 +1,95 @@
+#include <cnl.h>
+
+namespace
+{
+
+template<
+    int IntegerDigits,
+    class RoundingTag = cnl::nearest_rounding_tag,
+    class Narrowest = int>
+using rounding_elastic_integer = cnl::rounding_integer<
+    cnl::elastic_integer<
+        IntegerDigits,
+        Narrowest>,
+    RoundingTag>;
+
+template<int Digits, int Exponent = 0, class RoundingTag = cnl::nearest_rounding_tag, class Narrowest = signed>
+using rounding_elastic_number = cnl::fixed_point<rounding_elastic_integer<Digits, RoundingTag, Narrowest>, Exponent>;
+
+namespace test_addition
+{
+static constexpr auto lhs = rounding_elastic_number<16>{1};
+static constexpr auto rhs = rounding_elastic_number<16, -8>{1};
+static constexpr auto expected = rounding_elastic_number<25, -8>{2};
+static constexpr auto sum = lhs + rhs;
+static_assert(identical(expected, sum), "rounding_elastic_number addition");
+}
+
+namespace test_addition_larger {
+static constexpr auto lhs = rounding_elastic_number<32>{1};
+static constexpr auto rhs = rounding_elastic_number<32, -30>{1};
+static constexpr auto expected = rounding_elastic_number<63, -30>{2};
+static constexpr auto sum = lhs + rhs;
+static_assert(identical(expected, sum), "larger rounding_elastic_number addition");
+}
+
+namespace test_division
+{
+
+static_assert(identical(
+    rounding_elastic_number<16, -8>{.5},
+    cnl::divide<cnl::nearest_rounding_tag,
+        rounding_elastic_number<8, 0>,
+        rounding_elastic_number<8, 0> >()(rounding_elastic_number<8, 0>{1},
+                                          rounding_elastic_number<8, 0>{2})),
+              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+
+static_assert(identical(
+    rounding_elastic_number<62, -31>{2.},
+    cnl::divide<cnl::nearest_rounding_tag,
+        rounding_elastic_number<31, 0>,
+        rounding_elastic_number<31, 0> >()(rounding_elastic_number<31, 0>{2},
+                                           rounding_elastic_number<31, 0>{1})),
+              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+
+#if defined(CNL_INT128_ENABLED)
+static_assert(identical(
+    rounding_elastic_number<96, -48>{2.},
+    cnl::divide<cnl::nearest_rounding_tag,
+        rounding_elastic_number<48, 0>,
+        rounding_elastic_number<48, 0> >()(rounding_elastic_number<48, 0>{2},
+                                           rounding_elastic_number<48, 0>{1})),
+              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+#endif
+
+static_assert(identical(
+    rounding_elastic_number<16, -8>{.5},
+    cnl::divide<cnl::nearest_rounding_tag,
+        rounding_elastic_number<8, -4>,
+        rounding_elastic_number<8,-4> >()(rounding_elastic_number<8, -4>{1},
+                                           rounding_elastic_number<8, -4>{2})),
+              "cnl::divide(rounding_elastic_number, rounding_elastic_number)");
+
+ static_assert(identical(
+    rounding_elastic_number<16, -8>{.5},
+    make_fixed_point(cnl::make_fractional(rounding_elastic_number<8, 0>{1}, rounding_elastic_number<8, 0>{2}))),
+              "cnl::rounding_elastic_number division");
+
+static_assert(identical(
+    rounding_elastic_number<62, -31>{.5},
+    make_fixed_point(cnl::make_fractional(rounding_elastic_number<31, 0>{1}, rounding_elastic_number<31, 0>{2}))),
+              "cnl::rounding_elastic_number division");
+
+#if defined(CNL_INT128_ENABLED)
+static_assert(identical(
+    rounding_elastic_number<96, -48>{.5},
+    make_fixed_point(cnl::make_fractional(rounding_elastic_number<48, 0>{1}, rounding_elastic_number<48, 0>{2}))),
+              "cnl::rounding_elastic_number division");
+
+static_assert(identical(
+            rounding_elastic_number<124, -62>{.5},
+            make_fixed_point(cnl::make_fractional(rounding_elastic_number<62, 0>{1}, rounding_elastic_number<62, 0>{2}))),
+            "cnl::rounding_elastic_number division");
+#endif
+}
+}


### PR DESCRIPTION
I'm still getting used to multiple remotes and I accidentally pushed to *hbe72/cnl/rounding_elastic_number* most of these changes already. This is the same branch rebased onto the fix in *develop*. Feel free to merge/replace/squash/revert as you see fit.