### PR TITLE
Math constants

### DIFF
--- a/include/cnl/bits/fixed_point/constants.h
+++ b/include/cnl/bits/fixed_point/constants.h
@@ -89,97 +89,95 @@ namespace cnl {
         }
     }
 
-    namespace math_constants {
-        /// specialization of \ref cnl::math_constants::e for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> e<fixed_point<Rep, Exponent>> {
-            _impl::constant_with_fallback<long double, Rep, Exponent>(e<long double>, _impl::e<Rep, Exponent>)
-        };
+    /// specialization of \ref cnl::e for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> e<fixed_point<Rep, Exponent>> {
+        _impl::constant_with_fallback<long double, Rep, Exponent>(e<long double>, _impl::e<Rep, Exponent>)
+    };
 
-        /// specialization of \ref cnl::math_constants::log2e for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> log2e<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ log2e<long double> }
-        };
+    /// specialization of \ref cnl::log2e for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> log2e<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ log2e<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::log10e for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> log10e<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ log10e<long double> }
-        };
+    /// specialization of \ref cnl::log10e for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> log10e<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ log10e<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::pi for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> pi<fixed_point<Rep, Exponent>>{
-            _impl::constant_with_fallback<long double, Rep, Exponent>(pi<long double>, _impl::pi<Rep, Exponent>)
-        };
+    /// specialization of \ref cnl::pi for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> pi<fixed_point<Rep, Exponent>>{
+        _impl::constant_with_fallback<long double, Rep, Exponent>(pi<long double>, _impl::pi<Rep, Exponent>)
+    };
 
-        /// specialization of \ref cnl::math_constants::invpi for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invpi<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ invpi<long double> }
-        };
+    /// specialization of \ref cnl::invpi for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invpi<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ invpi<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::invsqrtpi for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invsqrtpi<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ invsqrtpi<long double> }
-        };
+    /// specialization of \ref cnl::invsqrtpi for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invsqrtpi<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ invsqrtpi<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::ln2 for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> ln2<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ ln2<long double> }
-        };
+    /// specialization of \ref cnl::ln2 for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> ln2<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ ln2<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::ln10 for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> ln10<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ ln10<long double> }
-        };
+    /// specialization of \ref cnl::ln10 for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> ln10<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ ln10<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::sqrt2 for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> sqrt2<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ sqrt2<long double> }
-        };
+    /// specialization of \ref cnl::sqrt2 for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> sqrt2<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ sqrt2<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::sqrt3 for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> sqrt3<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ sqrt3<long double> }
-        };
+    /// specialization of \ref cnl::sqrt3 for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> sqrt3<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ sqrt3<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::invsqrt2 for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invsqrt2<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ invsqrt2<long double> }
-        };
+    /// specialization of \ref cnl::invsqrt2 for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invsqrt2<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ invsqrt2<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::invsqrt3 for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invsqrt3<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ invsqrt3<long double> }
-        };
+    /// specialization of \ref cnl::invsqrt3 for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> invsqrt3<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ invsqrt3<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::radian for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> radian<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ radian<long double> }
-        };
+    /// specialization of \ref cnl::radian for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> radian<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ radian<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::egamma for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> egamma<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ egamma<long double> }
-        };
+    /// specialization of \ref cnl::egamma for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> egamma<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ egamma<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::phi for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> phi<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ phi<long double> }
-        };
+    /// specialization of \ref cnl::phi for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> phi<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ phi<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::catalan for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> catalan<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ catalan<long double> }
-        };
+    /// specialization of \ref cnl::catalan for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> catalan<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ catalan<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::apery for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> apery<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ apery<long double> }
-        };
+    /// specialization of \ref cnl::apery for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> apery<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ apery<long double> }
+    };
 
-        /// specialization of \ref cnl::math_constants::glaisher for \ref cnl::fixed_point
-        template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> glaisher<fixed_point<Rep, Exponent>> {
-            fixed_point<Rep, Exponent>{ glaisher<long double> }
-        };
-    }
+    /// specialization of \ref cnl::glaisher for \ref cnl::fixed_point
+    template<typename Rep, int Exponent> inline constexpr fixed_point<Rep, Exponent> glaisher<fixed_point<Rep, Exponent>> {
+        fixed_point<Rep, Exponent>{ glaisher<long double> }
+    };
 #endif  // defined(__cpp_inline_variables)
 }
 

--- a/include/cnl/numeric.h
+++ b/include/cnl/numeric.h
@@ -19,253 +19,251 @@ namespace cnl {
     // cnl::math_constants
     
 #if defined(__cpp_inline_variables)
-    /// contains math constants as variable templates;
     /// partial implementation of [P0631](http://wg21.link/p0631)
-    namespace math_constants {
-        // values taken from c++ (GCC) 7.2.0 implementation of math.h; disclaimer: may be a bit or two off
 
-        ////////////////////////////////////////////////////////////////////////////////
-        // primary templates
+    // values taken from c++ (GCC) 7.2.0 implementation of math.h; disclaimer: may be a bit or two off
 
-        /// approximation of [e](https://en.wikipedia.org/wiki/E_(mathematical_constant));
-        /// primary variable template
-        template<typename T> inline constexpr T e{_impl::deleted_fn<T>()};
+    ////////////////////////////////////////////////////////////////////////////////
+    // primary templates
 
-        /// approximation of the [binary logarithm](https://en.wikipedia.org/wiki/Binary_logarithm) of e, `log2(e)`;
-        /// primary variable template
-        template<typename T> inline constexpr T log2e{_impl::deleted_fn<T>()};
+    /// approximation of [e](https://en.wikipedia.org/wiki/E_(mathematical_constant));
+    /// primary variable template
+    template<typename T> inline constexpr T e{_impl::deleted_fn<T>()};
 
-        /// approximation of the [decimal logarithm](https://en.wikipedia.org/wiki/Binary_logarithm) of e, `log10(e)`;
-        /// primary variable template
-        template<typename T> inline constexpr T log10e{_impl::deleted_fn<T>()};
+    /// approximation of the [binary logarithm](https://en.wikipedia.org/wiki/Binary_logarithm) of e, `log2(e)`;
+    /// primary variable template
+    template<typename T> inline constexpr T log2e{_impl::deleted_fn<T>()};
 
-        /// approximation of [pi](https://en.wikipedia.org/wiki/Pi);
-        /// primary variable template
-        template<typename T> inline constexpr T pi{_impl::deleted_fn<T>()};
+    /// approximation of the [decimal logarithm](https://en.wikipedia.org/wiki/Binary_logarithm) of e, `log10(e)`;
+    /// primary variable template
+    template<typename T> inline constexpr T log10e{_impl::deleted_fn<T>()};
 
-        /// approximation of `1/pi`;
-        /// primary variable template
-        template<typename T> inline constexpr T invpi{_impl::deleted_fn<T>()};
+    /// approximation of [pi](https://en.wikipedia.org/wiki/Pi);
+    /// primary variable template
+    template<typename T> inline constexpr T pi{_impl::deleted_fn<T>()};
 
-        /// approximation of `1/sqrt(pi)`;
-        /// primary variable template
-        template<typename T> inline constexpr T invsqrtpi{_impl::deleted_fn<T>()};
+    /// approximation of `1/pi`;
+    /// primary variable template
+    template<typename T> inline constexpr T invpi{_impl::deleted_fn<T>()};
 
-        /// approximation of the [natural logarithm](https://en.wikipedia.org/wiki/Natural_logarithm) of 2, `ln(2)`;
-        /// primary variable template
-        template<typename T> inline constexpr T ln2{_impl::deleted_fn<T>()};
+    /// approximation of `1/sqrt(pi)`;
+    /// primary variable template
+    template<typename T> inline constexpr T invsqrtpi{_impl::deleted_fn<T>()};
 
-        /// approximation of the [natural logarithm](https://en.wikipedia.org/wiki/Natural_logarithm) of 10, `ln(10)`;
-        /// primary variable template
-        template<typename T> inline constexpr T ln10{_impl::deleted_fn<T>()};
+    /// approximation of the [natural logarithm](https://en.wikipedia.org/wiki/Natural_logarithm) of 2, `ln(2)`;
+    /// primary variable template
+    template<typename T> inline constexpr T ln2{_impl::deleted_fn<T>()};
 
-        /// approximation of the square root of 2, `sqrt(2)`;
-        /// primary variable template
-        template<typename T> inline constexpr T sqrt2{_impl::deleted_fn<T>()};
+    /// approximation of the [natural logarithm](https://en.wikipedia.org/wiki/Natural_logarithm) of 10, `ln(10)`;
+    /// primary variable template
+    template<typename T> inline constexpr T ln10{_impl::deleted_fn<T>()};
 
-        /// approximation of the square root of 3, `sqrt(3)`;
-        /// primary variable template
-        template<typename T> inline constexpr T sqrt3{_impl::deleted_fn<T>()};
+    /// approximation of the square root of 2, `sqrt(2)`;
+    /// primary variable template
+    template<typename T> inline constexpr T sqrt2{_impl::deleted_fn<T>()};
 
-        /// approximation of the inverse of the square root of 2, `1/sqrt(2)`;
-        /// primary variable template
-        template<typename T> inline constexpr T invsqrt2{sqrt2<T>/2};
+    /// approximation of the square root of 3, `sqrt(3)`;
+    /// primary variable template
+    template<typename T> inline constexpr T sqrt3{_impl::deleted_fn<T>()};
 
-        /// approximation of the inverse of the square root of 3, `1/sqrt(3)`;
-        /// primary variable template
-        template<typename T> inline constexpr T invsqrt3{_impl::deleted_fn<T>()};
+    /// approximation of the inverse of the square root of 2, `1/sqrt(2)`;
+    /// primary variable template
+    template<typename T> inline constexpr T invsqrt2{sqrt2<T>/2};
 
-        /// approximation of a radian in degrees, `180/pi`;
-        /// primary variable template
-        template<typename T> inline constexpr T radian{_impl::deleted_fn<T>()};
+    /// approximation of the inverse of the square root of 3, `1/sqrt(3)`;
+    /// primary variable template
+    template<typename T> inline constexpr T invsqrt3{_impl::deleted_fn<T>()};
 
-        /// approximation of the [Euler–Mascheroni constant](https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant);
-        /// primary variable template
-        template<typename T> inline constexpr T egamma{_impl::deleted_fn<T>()};
+    /// approximation of a radian in degrees, `180/pi`;
+    /// primary variable template
+    template<typename T> inline constexpr T radian{_impl::deleted_fn<T>()};
 
-        /// approximation of the [golden ratio](https://en.wikipedia.org/wiki/Golden_ratio);
-        /// primary variable template
-        template<typename T> inline constexpr T phi{_impl::deleted_fn<T>()};
+    /// approximation of the [Euler–Mascheroni constant](https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant);
+    /// primary variable template
+    template<typename T> inline constexpr T egamma{_impl::deleted_fn<T>()};
 
-        /// approximation of [Catalan's constant](https://en.wikipedia.org/wiki/Catalan%27s_constant);
-        /// primary variable template
-        template<typename T> inline constexpr T catalan{_impl::deleted_fn<T>()};
+    /// approximation of the [golden ratio](https://en.wikipedia.org/wiki/Golden_ratio);
+    /// primary variable template
+    template<typename T> inline constexpr T phi{_impl::deleted_fn<T>()};
 
-        /// approximation of [Apéry's constant](https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_constant);
-        /// primary variable template
-        template<typename T> inline constexpr T apery{_impl::deleted_fn<T>()};
+    /// approximation of [Catalan's constant](https://en.wikipedia.org/wiki/Catalan%27s_constant);
+    /// primary variable template
+    template<typename T> inline constexpr T catalan{_impl::deleted_fn<T>()};
 
-        /// approximation of the [Glaisher–Kinkelin constant](https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant);
-        /// primary variable template
-        template<typename T> inline constexpr T glaisher{_impl::deleted_fn<T>()};
+    /// approximation of [Apéry's constant](https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_constant);
+    /// primary variable template
+    template<typename T> inline constexpr T apery{_impl::deleted_fn<T>()};
 
-        ////////////////////////////////////////////////////////////////////////////////
-        // long double specializations
+    /// approximation of the [Glaisher–Kinkelin constant](https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant);
+    /// primary variable template
+    template<typename T> inline constexpr T glaisher{_impl::deleted_fn<T>()};
 
-        /// specialization of \ref cnl::math_constants::e for `long double`
-        template<> inline constexpr long double e<long double>{2.718281828459045235360287471352662498L};
+    ////////////////////////////////////////////////////////////////////////////////
+    // long double specializations
 
-        /// specialization of \ref cnl::math_constants::log2e for `long double`
-        template<> inline constexpr long double log2e<long double>{1.442695040888963407359924681001892137L};
+    /// specialization of \ref cnl::math_constants::e for `long double`
+    template<> inline constexpr long double e<long double>{2.718281828459045235360287471352662498L};
 
-        /// specialization of \ref cnl::math_constants::log10e for `long double`
-        template<> inline constexpr long double log10e<long double>{0.434294481903251827651128918916605082L};
+    /// specialization of \ref cnl::math_constants::log2e for `long double`
+    template<> inline constexpr long double log2e<long double>{1.442695040888963407359924681001892137L};
 
-        /// specialization of \ref cnl::math_constants::pi for `long double`
-        template<> inline constexpr long double pi<long double>{3.141592653589793238462643383279502884L};
+    /// specialization of \ref cnl::math_constants::log10e for `long double`
+    template<> inline constexpr long double log10e<long double>{0.434294481903251827651128918916605082L};
 
-        /// specialization of \ref cnl::math_constants::invpi for `long double`
-        template<> inline constexpr long double invpi<long double>{0.318309886183790671537767526745028724L};
+    /// specialization of \ref cnl::math_constants::pi for `long double`
+    template<> inline constexpr long double pi<long double>{3.141592653589793238462643383279502884L};
 
-        /// specialization of \ref cnl::math_constants::invsqrtpi for `long double`
-        template<> inline constexpr long double invsqrtpi<long double>{
-                0.564189583547756286948079451560772585844050629329L};
+    /// specialization of \ref cnl::math_constants::invpi for `long double`
+    template<> inline constexpr long double invpi<long double>{0.318309886183790671537767526745028724L};
 
-        /// specialization of \ref cnl::math_constants::ln2 for `long double`
-        template<> inline constexpr long double ln2<long double>{0.693147180559945309417232121458176568L};
+    /// specialization of \ref cnl::math_constants::invsqrtpi for `long double`
+    template<> inline constexpr long double invsqrtpi<long double>{
+            0.564189583547756286948079451560772585844050629329L};
 
-        /// specialization of \ref cnl::math_constants::ln10 for `long double`
-        template<> inline constexpr long double ln10<long double>{2.302585092994045684017991454684364208L};
+    /// specialization of \ref cnl::math_constants::ln2 for `long double`
+    template<> inline constexpr long double ln2<long double>{0.693147180559945309417232121458176568L};
 
-        /// specialization of \ref cnl::math_constants::sqrt2 for `long double`
-        template<> inline constexpr long double sqrt2<long double>{1.414213562373095048801688724209698079L};
+    /// specialization of \ref cnl::math_constants::ln10 for `long double`
+    template<> inline constexpr long double ln10<long double>{2.302585092994045684017991454684364208L};
 
-        /// specialization of \ref cnl::math_constants::sqrt3 for `long double`
-        template<> inline constexpr long double sqrt3<long double>{
-                1.73205080756887729352744634150587236694280525381038062805580L};
+    /// specialization of \ref cnl::math_constants::sqrt2 for `long double`
+    template<> inline constexpr long double sqrt2<long double>{1.414213562373095048801688724209698079L};
 
-        /// specialization of \ref cnl::math_constants::invsqrt3 for `long double`
-        template<> inline constexpr long double invsqrt3<long double>{
-                0.57735026918962576450914878050195745564760175127013L};
+    /// specialization of \ref cnl::math_constants::sqrt3 for `long double`
+    template<> inline constexpr long double sqrt3<long double>{
+            1.73205080756887729352744634150587236694280525381038062805580L};
 
-        /// specialization of \ref cnl::math_constants::radian for `long double`
-        template<> inline constexpr long double radian<long double>{
-                57.295779513082320876798154814105170332405472466564L};
+    /// specialization of \ref cnl::math_constants::invsqrt3 for `long double`
+    template<> inline constexpr long double invsqrt3<long double>{
+            0.57735026918962576450914878050195745564760175127013L};
 
-        /// specialization of \ref cnl::math_constants::egamma for `long double`
-        template<> inline constexpr long double egamma<long double>{0.5772156649015328606065120900824024L};
+    /// specialization of \ref cnl::math_constants::radian for `long double`
+    template<> inline constexpr long double radian<long double>{
+            57.295779513082320876798154814105170332405472466564L};
 
-        /// specialization of \ref cnl::math_constants::phi for `long double`
-        template<> inline constexpr long double phi<long double>{1.6180339887498948482045868343656381L};
+    /// specialization of \ref cnl::math_constants::egamma for `long double`
+    template<> inline constexpr long double egamma<long double>{0.5772156649015328606065120900824024L};
 
-        /// specialization of \ref cnl::math_constants::catalan for `long double`
-        template<> inline constexpr long double catalan<long double>{0.915965594177219015054603514932384110774L};
+    /// specialization of \ref cnl::math_constants::phi for `long double`
+    template<> inline constexpr long double phi<long double>{1.6180339887498948482045868343656381L};
 
-        /// specialization of \ref cnl::math_constants::apery for `long double`
-        template<> inline constexpr long double apery<long double>{1.202056903159594285399738161511449990L};
+    /// specialization of \ref cnl::math_constants::catalan for `long double`
+    template<> inline constexpr long double catalan<long double>{0.915965594177219015054603514932384110774L};
 
-        /// specialization of \ref cnl::math_constants::glaisher for `long double`
-        template<> inline constexpr long double glaisher<long double>{1.282427129100622636875342568869791727L};
+    /// specialization of \ref cnl::math_constants::apery for `long double`
+    template<> inline constexpr long double apery<long double>{1.202056903159594285399738161511449990L};
 
-        ////////////////////////////////////////////////////////////////////////////////
-        // double specializations
+    /// specialization of \ref cnl::math_constants::glaisher for `long double`
+    template<> inline constexpr long double glaisher<long double>{1.282427129100622636875342568869791727L};
 
-        /// specialization of \ref cnl::math_constants::e for `double`
-        template<> inline constexpr double e<double>{2.7182818284590452354};
+    ////////////////////////////////////////////////////////////////////////////////
+    // double specializations
 
-        /// specialization of \ref cnl::math_constants::log2e for `double`
-        template<> inline constexpr double log2e<double>{1.4426950408889634074};
+    /// specialization of \ref cnl::math_constants::e for `double`
+    template<> inline constexpr double e<double>{2.7182818284590452354};
 
-        /// specialization of \ref cnl::math_constants::log10e for `double`
-        template<> inline constexpr double log10e<double>{0.43429448190325182765};
+    /// specialization of \ref cnl::math_constants::log2e for `double`
+    template<> inline constexpr double log2e<double>{1.4426950408889634074};
 
-        /// specialization of \ref cnl::math_constants::pi for `double`
-        template<> inline constexpr double pi<double>{3.14159265358979323846};
+    /// specialization of \ref cnl::math_constants::log10e for `double`
+    template<> inline constexpr double log10e<double>{0.43429448190325182765};
 
-        /// specialization of \ref cnl::math_constants::invpi for `double`
-        template<> inline constexpr double invpi<double>{0.31830988618379067154};
+    /// specialization of \ref cnl::math_constants::pi for `double`
+    template<> inline constexpr double pi<double>{3.14159265358979323846};
 
-        /// specialization of \ref cnl::math_constants::invsqrtpi for `double`
-        template<> inline constexpr double invsqrtpi<double>{0.564189583547756286948079451560772585844050629329};
+    /// specialization of \ref cnl::math_constants::invpi for `double`
+    template<> inline constexpr double invpi<double>{0.31830988618379067154};
 
-        /// specialization of \ref cnl::math_constants::ln2 for `double`
-        template<> inline constexpr double ln2<double>{0.69314718055994530942};
+    /// specialization of \ref cnl::math_constants::invsqrtpi for `double`
+    template<> inline constexpr double invsqrtpi<double>{0.564189583547756286948079451560772585844050629329};
 
-        /// specialization of \ref cnl::math_constants::ln10 for `double`
-        template<> inline constexpr double ln10<double>{2.30258509299404568402};
+    /// specialization of \ref cnl::math_constants::ln2 for `double`
+    template<> inline constexpr double ln2<double>{0.69314718055994530942};
 
-        /// specialization of \ref cnl::math_constants::sqrt2 for `double`
-        template<> inline constexpr double sqrt2<double>{1.41421356237309504880};
+    /// specialization of \ref cnl::math_constants::ln10 for `double`
+    template<> inline constexpr double ln10<double>{2.30258509299404568402};
 
-        /// specialization of \ref cnl::math_constants::sqrt3 for `double`
-        template<> inline constexpr double sqrt3<double>{
-                1.73205080756887729352744634150587236694280525381038062805580};
+    /// specialization of \ref cnl::math_constants::sqrt2 for `double`
+    template<> inline constexpr double sqrt2<double>{1.41421356237309504880};
 
-        /// specialization of \ref cnl::math_constants::invsqrt3 for `double`
-        template<> inline constexpr double invsqrt3<double>{0.57735026918962576450914878050195745564760175127013};
+    /// specialization of \ref cnl::math_constants::sqrt3 for `double`
+    template<> inline constexpr double sqrt3<double>{
+            1.73205080756887729352744634150587236694280525381038062805580};
 
-        /// specialization of \ref cnl::math_constants::radian for `double`
-        template<> inline constexpr double radian<double>{57.295779513082320876798154814105170332405472466564};
+    /// specialization of \ref cnl::math_constants::invsqrt3 for `double`
+    template<> inline constexpr double invsqrt3<double>{0.57735026918962576450914878050195745564760175127013};
 
-        /// specialization of \ref cnl::math_constants::egamma for `double`
-        template<> inline constexpr double egamma<double>{0.5772156649015328606065120900824024};
+    /// specialization of \ref cnl::math_constants::radian for `double`
+    template<> inline constexpr double radian<double>{57.295779513082320876798154814105170332405472466564};
 
-        /// specialization of \ref cnl::math_constants::phi for `double`
-        template<> inline constexpr double phi<double>{1.6180339887498948482045868343656381};
+    /// specialization of \ref cnl::math_constants::egamma for `double`
+    template<> inline constexpr double egamma<double>{0.5772156649015328606065120900824024};
 
-        /// specialization of \ref cnl::math_constants::catalan for `double`
-        template<> inline constexpr double catalan<double>{0.915965594177219015054603514932384110774};
+    /// specialization of \ref cnl::math_constants::phi for `double`
+    template<> inline constexpr double phi<double>{1.6180339887498948482045868343656381};
 
-        /// specialization of \ref cnl::math_constants::apery for `double`
-        template<> inline constexpr double apery<double>{1.202056903159594285399738161511449990};
+    /// specialization of \ref cnl::math_constants::catalan for `double`
+    template<> inline constexpr double catalan<double>{0.915965594177219015054603514932384110774};
 
-        /// specialization of \ref cnl::math_constants::glaisher for `double`
-        template<> inline constexpr double glaisher<double>{1.282427129100622636875342568869791727};
+    /// specialization of \ref cnl::math_constants::apery for `double`
+    template<> inline constexpr double apery<double>{1.202056903159594285399738161511449990};
 
-        ////////////////////////////////////////////////////////////////////////////////
-        // float specializations
+    /// specialization of \ref cnl::math_constants::glaisher for `double`
+    template<> inline constexpr double glaisher<double>{1.282427129100622636875342568869791727};
 
-        /// specialization of \ref cnl::math_constants::e for `float`
-        template<> inline constexpr float e<float>{2.7182818284590452354f};
+    ////////////////////////////////////////////////////////////////////////////////
+    // float specializations
 
-        /// specialization of \ref cnl::math_constants::log2e for `float`
-        template<> inline constexpr float log2e<float>{1.4426950408889634074f};
+    /// specialization of \ref cnl::math_constants::e for `float`
+    template<> inline constexpr float e<float>{2.7182818284590452354f};
 
-        /// specialization of \ref cnl::math_constants::log10e for `float`
-        template<> inline constexpr float log10e<float>{0.43429448190325182765f};
+    /// specialization of \ref cnl::math_constants::log2e for `float`
+    template<> inline constexpr float log2e<float>{1.4426950408889634074f};
 
-        /// specialization of \ref cnl::math_constants::pi for `float`
-        template<> inline constexpr float pi<float>{3.14159265358979323846f};
+    /// specialization of \ref cnl::math_constants::log10e for `float`
+    template<> inline constexpr float log10e<float>{0.43429448190325182765f};
 
-        /// specialization of \ref cnl::math_constants::invpi for `float`
-        template<> inline constexpr float invpi<float>{0.31830988618379067154f};
+    /// specialization of \ref cnl::math_constants::pi for `float`
+    template<> inline constexpr float pi<float>{3.14159265358979323846f};
 
-        /// specialization of \ref cnl::math_constants::invsqrtpi for `float`
-        template<> inline constexpr float invsqrtpi<float>{0.564189583547756286948079451560772585844050629329f};
+    /// specialization of \ref cnl::math_constants::invpi for `float`
+    template<> inline constexpr float invpi<float>{0.31830988618379067154f};
 
-        /// specialization of \ref cnl::math_constants::ln2 for `float`
-        template<> inline constexpr float ln2<float>{0.69314718055994530942f};
+    /// specialization of \ref cnl::math_constants::invsqrtpi for `float`
+    template<> inline constexpr float invsqrtpi<float>{0.564189583547756286948079451560772585844050629329f};
 
-        /// specialization of \ref cnl::math_constants::ln10 for `float`
-        template<> inline constexpr float ln10<float>{2.30258509299404568402f};
+    /// specialization of \ref cnl::math_constants::ln2 for `float`
+    template<> inline constexpr float ln2<float>{0.69314718055994530942f};
 
-        /// specialization of \ref cnl::math_constants::sqrt2 for `float`
-        template<> inline constexpr float sqrt2<float>{1.41421356237309504880f};
+    /// specialization of \ref cnl::math_constants::ln10 for `float`
+    template<> inline constexpr float ln10<float>{2.30258509299404568402f};
 
-        /// specialization of \ref cnl::math_constants::sqrt3 for `float`
-        template<> inline constexpr float sqrt3<float>{1.73205080756887729352744634150587236694280525381038062805580f};
+    /// specialization of \ref cnl::math_constants::sqrt2 for `float`
+    template<> inline constexpr float sqrt2<float>{1.41421356237309504880f};
 
-        /// specialization of \ref cnl::math_constants::invsqrt3 for `float`
-        template<> inline constexpr float invsqrt3<float>{0.57735026918962576450914878050195745564760175127013f};
+    /// specialization of \ref cnl::math_constants::sqrt3 for `float`
+    template<> inline constexpr float sqrt3<float>{1.73205080756887729352744634150587236694280525381038062805580f};
 
-        /// specialization of \ref cnl::math_constants::radian for `float`
-        template<> inline constexpr float radian<float>{57.295779513082320876798154814105170332405472466564f};
+    /// specialization of \ref cnl::math_constants::invsqrt3 for `float`
+    template<> inline constexpr float invsqrt3<float>{0.57735026918962576450914878050195745564760175127013f};
 
-        /// specialization of \ref cnl::math_constants::egamma for `float`
-        template<> inline constexpr float egamma<float>{0.5772156649015328606065120900824024f};
+    /// specialization of \ref cnl::math_constants::radian for `float`
+    template<> inline constexpr float radian<float>{57.295779513082320876798154814105170332405472466564f};
 
-        /// specialization of \ref cnl::math_constants::phi for `float`
-        template<> inline constexpr float phi<float>{1.6180339887498948482045868343656381f};
+    /// specialization of \ref cnl::math_constants::egamma for `float`
+    template<> inline constexpr float egamma<float>{0.5772156649015328606065120900824024f};
 
-        /// specialization of \ref cnl::math_constants::catalan for `float`
-        template<> inline constexpr float catalan<float>{0.915965594177219015054603514932384110774f};
+    /// specialization of \ref cnl::math_constants::phi for `float`
+    template<> inline constexpr float phi<float>{1.6180339887498948482045868343656381f};
 
-        /// specialization of \ref cnl::math_constants::apery for `float`
-        template<> inline constexpr float apery<float>{1.202056903159594285399738161511449990f};
+    /// specialization of \ref cnl::math_constants::catalan for `float`
+    template<> inline constexpr float catalan<float>{0.915965594177219015054603514932384110774f};
 
-        /// specialization of \ref cnl::math_constants::glaisher for `float`
-        template<> inline constexpr float glaisher<float>{1.282427129100622636875342568869791727f};
-    }
+    /// specialization of \ref cnl::math_constants::apery for `float`
+    template<> inline constexpr float apery<float>{1.202056903159594285399738161511449990f};
+
+    /// specialization of \ref cnl::math_constants::glaisher for `float`
+    template<> inline constexpr float glaisher<float>{1.282427129100622636875342568869791727f};
 #endif  // defined(__cpp_inline_variables)
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/test/fixed_point/constants.cpp
+++ b/src/test/fixed_point/constants.cpp
@@ -14,15 +14,14 @@ namespace {
 
     using cnl::_impl::identical;
     using cnl::fixed_point;
-    using namespace cnl::math_constants;
 
     ////////////////////////////////////////////////////////////////////////////////
     // simple one-off tests
 
     // 8-bit pi
     static_assert(
-            identical(fixed_point<cnl::uint8, -6>{3.140625}, pi<fixed_point<cnl::uint8, -6>>),
-            "cnl::math_constants::pi test failed");
+            identical(fixed_point<cnl::uint8, -6>{3.140625}, cnl::pi<fixed_point<cnl::uint8, -6>>),
+            "cnl::pi test failed");
 
     ////////////////////////////////////////////////////////////////////////////////
     // precision tests
@@ -39,129 +38,129 @@ namespace {
     }
 
     TEST(fixed_point_constants, e) {
-        EXPECT_LT(get_error(e<fixed_point<cnl::uint8, -6>>, e<long double>), .006L);
-        EXPECT_LT(get_error(e<fixed_point<cnl::int16, -4>>, e<long double>), .015L);
-        EXPECT_LT(get_error(e<fixed_point<cnl::int32, -16>>, e<long double>), .000002L);
-        EXPECT_LT(get_error(e<fixed_point<cnl::uint64, -62>>, e<long double>), .0000000000000000000000000000002L);
+        EXPECT_LT(get_error(cnl::e<fixed_point<cnl::uint8, -6>>, cnl::e<long double>), .006L);
+        EXPECT_LT(get_error(cnl::e<fixed_point<cnl::int16, -4>>, cnl::e<long double>), .015L);
+        EXPECT_LT(get_error(cnl::e<fixed_point<cnl::int32, -16>>, cnl::e<long double>), .000002L);
+        EXPECT_LT(get_error(cnl::e<fixed_point<cnl::uint64, -62>>, cnl::e<long double>), .0000000000000000000000000000002L);
     }
 
     TEST(fixed_point_constants, log2e) {
-        EXPECT_LT(get_error(log2e<fixed_point<cnl::uint8, -6>>, log2e<long double>), .006L);
-        EXPECT_LT(get_error(log2e<fixed_point<cnl::int16, -4>>, log2e<long double>), .015L);
-        EXPECT_LT(get_error(log2e<fixed_point<cnl::int32, -16>>, log2e<long double>), .000005L);
-        EXPECT_LT(get_error(log2e<fixed_point<cnl::uint64, -62>>, log2e<long double>), .0000000000000000002L);
+        EXPECT_LT(get_error(cnl::log2e<fixed_point<cnl::uint8, -6>>, cnl::log2e<long double>), .006L);
+        EXPECT_LT(get_error(cnl::log2e<fixed_point<cnl::int16, -4>>, cnl::log2e<long double>), .015L);
+        EXPECT_LT(get_error(cnl::log2e<fixed_point<cnl::int32, -16>>, cnl::log2e<long double>), .000005L);
+        EXPECT_LT(get_error(cnl::log2e<fixed_point<cnl::uint64, -62>>, cnl::log2e<long double>), .0000000000000000002L);
     }
 
     TEST(fixed_point_constants, log10e) {
-        EXPECT_LT(get_error(log10e<fixed_point<cnl::uint8, -6>>, log10e<long double>), .03L);
-        EXPECT_LT(get_error(log10e<fixed_point<cnl::int16, -4>>, log10e<long double>), .16L);
-        EXPECT_LT(get_error(log10e<fixed_point<cnl::int32, -16>>, log10e<long double>), .0000325L);
-        EXPECT_LT(get_error(log10e<fixed_point<cnl::uint64, -62>>, log10e<long double>), .0000000000000000004L);
+        EXPECT_LT(get_error(cnl::log10e<fixed_point<cnl::uint8, -6>>, cnl::log10e<long double>), .03L);
+        EXPECT_LT(get_error(cnl::log10e<fixed_point<cnl::int16, -4>>, cnl::log10e<long double>), .16L);
+        EXPECT_LT(get_error(cnl::log10e<fixed_point<cnl::int32, -16>>, cnl::log10e<long double>), .0000325L);
+        EXPECT_LT(get_error(cnl::log10e<fixed_point<cnl::uint64, -62>>, cnl::log10e<long double>), .0000000000000000004L);
     }
 
     TEST(fixed_point_constants, pi) {
-        EXPECT_LT(get_error(pi<fixed_point<cnl::uint8, -6>>, pi<long double>), .006L);
-        EXPECT_LT(get_error(pi<fixed_point<cnl::int16, -4>>, pi<long double>), .015L);
-        EXPECT_LT(get_error(pi<fixed_point<cnl::int32, -16>>, pi<long double>), .0000021L);
-        EXPECT_LT(get_error(pi<fixed_point<cnl::uint64, -62>>, pi<long double>), .0000000000000000002L);
+        EXPECT_LT(get_error(cnl::pi<fixed_point<cnl::uint8, -6>>, cnl::pi<long double>), .006L);
+        EXPECT_LT(get_error(cnl::pi<fixed_point<cnl::int16, -4>>, cnl::pi<long double>), .015L);
+        EXPECT_LT(get_error(cnl::pi<fixed_point<cnl::int32, -16>>, cnl::pi<long double>), .0000021L);
+        EXPECT_LT(get_error(cnl::pi<fixed_point<cnl::uint64, -62>>, cnl::pi<long double>), .0000000000000000002L);
     }
 
     TEST(fixed_point_constants, invpi) {
-        EXPECT_LT(get_error(invpi<fixed_point<cnl::uint8, -6>>, invpi<long double>), .02L);
-        EXPECT_LT(get_error(invpi<fixed_point<cnl::int16, -4>>, invpi<long double>), .02L);
-        EXPECT_LT(get_error(invpi<fixed_point<cnl::int32, -16>>, invpi<long double>), .00005L);
-        EXPECT_LT(get_error(invpi<fixed_point<cnl::uint64, -62>>, invpi<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::invpi<fixed_point<cnl::uint8, -6>>, cnl::invpi<long double>), .02L);
+        EXPECT_LT(get_error(cnl::invpi<fixed_point<cnl::int16, -4>>, cnl::invpi<long double>), .02L);
+        EXPECT_LT(get_error(cnl::invpi<fixed_point<cnl::int32, -16>>, cnl::invpi<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::invpi<fixed_point<cnl::uint64, -62>>, cnl::invpi<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, invsqrtpi) {
-        EXPECT_LT(get_error(invsqrtpi<fixed_point<cnl::uint8, -6>>, invsqrtpi<long double>), .02L);
-        EXPECT_LT(get_error(invsqrtpi<fixed_point<cnl::int16, -4>>, invsqrtpi<long double>), .02L);
-        EXPECT_LT(get_error(invsqrtpi<fixed_point<cnl::int32, -16>>, invsqrtpi<long double>), .00005L);
-        EXPECT_LT(get_error(invsqrtpi<fixed_point<cnl::uint64, -62>>, invsqrtpi<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::invsqrtpi<fixed_point<cnl::uint8, -6>>, cnl::invsqrtpi<long double>), .02L);
+        EXPECT_LT(get_error(cnl::invsqrtpi<fixed_point<cnl::int16, -4>>, cnl::invsqrtpi<long double>), .02L);
+        EXPECT_LT(get_error(cnl::invsqrtpi<fixed_point<cnl::int32, -16>>, cnl::invsqrtpi<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::invsqrtpi<fixed_point<cnl::uint64, -62>>, cnl::invsqrtpi<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, ln2) {
-        EXPECT_LT(get_error(ln2<fixed_point<cnl::uint8, -6>>, ln2<long double>), .01L);
-        EXPECT_LT(get_error(ln2<fixed_point<cnl::int16, -4>>, ln2<long double>), .015L);
-        EXPECT_LT(get_error(ln2<fixed_point<cnl::int32, -16>>, ln2<long double>), .0000021L);
-        EXPECT_LT(get_error(ln2<fixed_point<cnl::uint64, -62>>, ln2<long double>), .0000000000000000002L);
+        EXPECT_LT(get_error(cnl::ln2<fixed_point<cnl::uint8, -6>>, cnl::ln2<long double>), .01L);
+        EXPECT_LT(get_error(cnl::ln2<fixed_point<cnl::int16, -4>>, cnl::ln2<long double>), .015L);
+        EXPECT_LT(get_error(cnl::ln2<fixed_point<cnl::int32, -16>>, cnl::ln2<long double>), .0000021L);
+        EXPECT_LT(get_error(cnl::ln2<fixed_point<cnl::uint64, -62>>, cnl::ln2<long double>), .0000000000000000002L);
     }
 
     TEST(fixed_point_constants, ln10) {
-        EXPECT_LT(get_error(ln10<fixed_point<cnl::uint8, -6>>, ln10<long double>), .006L);
-        EXPECT_LT(get_error(ln10<fixed_point<cnl::int16, -4>>, ln10<long double>), .025L);
-        EXPECT_LT(get_error(ln10<fixed_point<cnl::int32, -16>>, ln10<long double>), .0000021L);
-        EXPECT_LT(get_error(ln10<fixed_point<cnl::uint64, -62>>, ln10<long double>), .0000000000000000002L);
+        EXPECT_LT(get_error(cnl::ln10<fixed_point<cnl::uint8, -6>>, cnl::ln10<long double>), .006L);
+        EXPECT_LT(get_error(cnl::ln10<fixed_point<cnl::int16, -4>>, cnl::ln10<long double>), .025L);
+        EXPECT_LT(get_error(cnl::ln10<fixed_point<cnl::int32, -16>>, cnl::ln10<long double>), .0000021L);
+        EXPECT_LT(get_error(cnl::ln10<fixed_point<cnl::uint64, -62>>, cnl::ln10<long double>), .0000000000000000002L);
     }
 
     TEST(fixed_point_constants, sqrt2) {
-        EXPECT_LT(get_error(sqrt2<fixed_point<cnl::uint8, -6>>, sqrt2<long double>), .006L);
-        EXPECT_LT(get_error(sqrt2<fixed_point<cnl::int16, -4>>, sqrt2<long double>), .03L);
-        EXPECT_LT(get_error(sqrt2<fixed_point<cnl::int32, -16>>, sqrt2<long double>), .00001L);
-        EXPECT_LT(get_error(sqrt2<fixed_point<cnl::uint64, -62>>, sqrt2<long double>), .0000000000000000002L);
+        EXPECT_LT(get_error(cnl::sqrt2<fixed_point<cnl::uint8, -6>>, cnl::sqrt2<long double>), .006L);
+        EXPECT_LT(get_error(cnl::sqrt2<fixed_point<cnl::int16, -4>>, cnl::sqrt2<long double>), .03L);
+        EXPECT_LT(get_error(cnl::sqrt2<fixed_point<cnl::int32, -16>>, cnl::sqrt2<long double>), .00001L);
+        EXPECT_LT(get_error(cnl::sqrt2<fixed_point<cnl::uint64, -62>>, cnl::sqrt2<long double>), .0000000000000000002L);
     }
 
     TEST(fixed_point_constants, sqrt3) {
-        EXPECT_LT(get_error(sqrt3<fixed_point<cnl::uint8, -6>>, sqrt3<long double>), .02L);
-        EXPECT_LT(get_error(sqrt3<fixed_point<cnl::int16, -4>>, sqrt3<long double>), .03L);
-        EXPECT_LT(get_error(sqrt3<fixed_point<cnl::int32, -16>>, sqrt3<long double>), .00005L);
-        EXPECT_LT(get_error(sqrt3<fixed_point<cnl::uint64, -62>>, sqrt3<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::sqrt3<fixed_point<cnl::uint8, -6>>, cnl::sqrt3<long double>), .02L);
+        EXPECT_LT(get_error(cnl::sqrt3<fixed_point<cnl::int16, -4>>, cnl::sqrt3<long double>), .03L);
+        EXPECT_LT(get_error(cnl::sqrt3<fixed_point<cnl::int32, -16>>, cnl::sqrt3<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::sqrt3<fixed_point<cnl::uint64, -62>>, cnl::sqrt3<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, invsqrt2) {
-        EXPECT_LT(get_error(invsqrt2<fixed_point<cnl::uint8, -6>>, invsqrt2<long double>), .02L);
-        EXPECT_LT(get_error(invsqrt2<fixed_point<cnl::int16, -4>>, invsqrt2<long double>), .03L);
-        EXPECT_LT(get_error(invsqrt2<fixed_point<cnl::int32, -16>>, invsqrt2<long double>), .00005L);
-        EXPECT_LT(get_error(invsqrt2<fixed_point<cnl::uint64, -62>>, invsqrt2<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::invsqrt2<fixed_point<cnl::uint8, -6>>, cnl::invsqrt2<long double>), .02L);
+        EXPECT_LT(get_error(cnl::invsqrt2<fixed_point<cnl::int16, -4>>, cnl::invsqrt2<long double>), .03L);
+        EXPECT_LT(get_error(cnl::invsqrt2<fixed_point<cnl::int32, -16>>, cnl::invsqrt2<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::invsqrt2<fixed_point<cnl::uint64, -62>>, cnl::invsqrt2<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, invsqrt3) {
-        EXPECT_LT(get_error(invsqrt3<fixed_point<cnl::uint8, -6>>, invsqrt3<long double>), .03L);
-        EXPECT_LT(get_error(invsqrt3<fixed_point<cnl::int16, -4>>, invsqrt3<long double>), .03L);
-        EXPECT_LT(get_error(invsqrt3<fixed_point<cnl::int32, -16>>, invsqrt3<long double>), .00005L);
-        EXPECT_LT(get_error(invsqrt3<fixed_point<cnl::uint64, -62>>, invsqrt3<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::invsqrt3<fixed_point<cnl::uint8, -6>>, cnl::invsqrt3<long double>), .03L);
+        EXPECT_LT(get_error(cnl::invsqrt3<fixed_point<cnl::int16, -4>>, cnl::invsqrt3<long double>), .03L);
+        EXPECT_LT(get_error(cnl::invsqrt3<fixed_point<cnl::int32, -16>>, cnl::invsqrt3<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::invsqrt3<fixed_point<cnl::uint64, -62>>, cnl::invsqrt3<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, radian) {
-        EXPECT_LT(get_error(radian<fixed_point<cnl::uint8, -1>>, radian<long double>), .02L);
-        EXPECT_LT(get_error(radian<fixed_point<cnl::int16, -4>>, radian<long double>), .02L);
-        EXPECT_LT(get_error(radian<fixed_point<cnl::int32, -16>>, radian<long double>), .00005L);
-        EXPECT_LT(get_error(radian<fixed_point<cnl::uint64, -58>>, radian<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::radian<fixed_point<cnl::uint8, -1>>, cnl::radian<long double>), .02L);
+        EXPECT_LT(get_error(cnl::radian<fixed_point<cnl::int16, -4>>, cnl::radian<long double>), .02L);
+        EXPECT_LT(get_error(cnl::radian<fixed_point<cnl::int32, -16>>, cnl::radian<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::radian<fixed_point<cnl::uint64, -58>>, cnl::radian<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, egamma) {
-        EXPECT_LT(get_error(egamma<fixed_point<cnl::uint8, -6>>, egamma<long double>), .03L);
-        EXPECT_LT(get_error(egamma<fixed_point<cnl::int16, -4>>, egamma<long double>), .03L);
-        EXPECT_LT(get_error(egamma<fixed_point<cnl::int32, -16>>, egamma<long double>), .00005L);
-        EXPECT_LT(get_error(egamma<fixed_point<cnl::uint64, -62>>, egamma<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::egamma<fixed_point<cnl::uint8, -6>>, cnl::egamma<long double>), .03L);
+        EXPECT_LT(get_error(cnl::egamma<fixed_point<cnl::int16, -4>>, cnl::egamma<long double>), .03L);
+        EXPECT_LT(get_error(cnl::egamma<fixed_point<cnl::int32, -16>>, cnl::egamma<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::egamma<fixed_point<cnl::uint64, -62>>, cnl::egamma<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, phi) {
-        EXPECT_LT(get_error(phi<fixed_point<cnl::uint8, -6>>, phi<long double>), .02L);
-        EXPECT_LT(get_error(phi<fixed_point<cnl::int16, -4>>, phi<long double>), .04L);
-        EXPECT_LT(get_error(phi<fixed_point<cnl::int32, -16>>, phi<long double>), .00005L);
-        EXPECT_LT(get_error(phi<fixed_point<cnl::uint64, -62>>, phi<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::phi<fixed_point<cnl::uint8, -6>>, cnl::phi<long double>), .02L);
+        EXPECT_LT(get_error(cnl::phi<fixed_point<cnl::int16, -4>>, cnl::phi<long double>), .04L);
+        EXPECT_LT(get_error(cnl::phi<fixed_point<cnl::int32, -16>>, cnl::phi<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::phi<fixed_point<cnl::uint64, -62>>, cnl::phi<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, catalan) {
-        EXPECT_LT(get_error(catalan<fixed_point<cnl::uint8, -6>>, catalan<long double>), .02L);
-        EXPECT_LT(get_error(catalan<fixed_point<cnl::int16, -4>>, catalan<long double>), .05L);
-        EXPECT_LT(get_error(catalan<fixed_point<cnl::int32, -16>>, catalan<long double>), .00005L);
-        EXPECT_LT(get_error(catalan<fixed_point<cnl::uint64, -62>>, catalan<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::catalan<fixed_point<cnl::uint8, -6>>, cnl::catalan<long double>), .02L);
+        EXPECT_LT(get_error(cnl::catalan<fixed_point<cnl::int16, -4>>, cnl::catalan<long double>), .05L);
+        EXPECT_LT(get_error(cnl::catalan<fixed_point<cnl::int32, -16>>, cnl::catalan<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::catalan<fixed_point<cnl::uint64, -62>>, cnl::catalan<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, apery) {
-        EXPECT_LT(get_error(apery<fixed_point<cnl::uint8, -6>>, apery<long double>), .02L);
-        EXPECT_LT(get_error(apery<fixed_point<cnl::int16, -4>>, apery<long double>), .02L);
-        EXPECT_LT(get_error(apery<fixed_point<cnl::int32, -16>>, apery<long double>), .00005L);
-        EXPECT_LT(get_error(apery<fixed_point<cnl::uint64, -62>>, apery<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::apery<fixed_point<cnl::uint8, -6>>, cnl::apery<long double>), .02L);
+        EXPECT_LT(get_error(cnl::apery<fixed_point<cnl::int16, -4>>, cnl::apery<long double>), .02L);
+        EXPECT_LT(get_error(cnl::apery<fixed_point<cnl::int32, -16>>, cnl::apery<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::apery<fixed_point<cnl::uint64, -62>>, cnl::apery<long double>), .0000000000000000003L);
     }
 
     TEST(fixed_point_constants, glaisher) {
-        EXPECT_LT(get_error(glaisher<fixed_point<cnl::uint8, -6>>, glaisher<long double>), .02L);
-        EXPECT_LT(get_error(glaisher<fixed_point<cnl::int16, -4>>, glaisher<long double>), .03L);
-        EXPECT_LT(get_error(glaisher<fixed_point<cnl::int32, -16>>, glaisher<long double>), .00005L);
-        EXPECT_LT(get_error(glaisher<fixed_point<cnl::uint64, -62>>, glaisher<long double>), .0000000000000000003L);
+        EXPECT_LT(get_error(cnl::glaisher<fixed_point<cnl::uint8, -6>>, cnl::glaisher<long double>), .02L);
+        EXPECT_LT(get_error(cnl::glaisher<fixed_point<cnl::int16, -4>>, cnl::glaisher<long double>), .03L);
+        EXPECT_LT(get_error(cnl::glaisher<fixed_point<cnl::int32, -16>>, cnl::glaisher<long double>), .00005L);
+        EXPECT_LT(get_error(cnl::glaisher<fixed_point<cnl::uint64, -62>>, cnl::glaisher<long double>), .0000000000000000003L);
     }
 
 #endif  // defined(__cpp_inline_variables)

--- a/src/test/fixed_point/fractional_ctor.h
+++ b/src/test/fixed_point/fractional_ctor.h
@@ -22,7 +22,7 @@ namespace {
         // pi stored as s5.10 (truncated rounding)
         constexpr auto n = cnl::from_rep<cnl::fixed_point<int16, -10>>()(int16{3216});
 #if defined(__cpp_inline_variables)
-        static_assert(identical(cnl::math_constants::pi<cnl::fixed_point<int16, -10>>, n));
+        static_assert(identical(cnl::pi<cnl::fixed_point<int16, -10>>, n));
 #endif
         static_assert(identical(int16{3216}, to_rep(n)), "cnl::to_rep(cnl::fixed_point)");
         static_assert(identical(3.140625, static_cast<double>(n)), "cnl::fixed_point::operator double()");

--- a/src/test/numeric.cpp
+++ b/src/test/numeric.cpp
@@ -20,8 +20,6 @@ namespace {
 #if defined(__cpp_inline_variables)
 
     namespace test_math_constants {
-        using namespace math_constants;
-
         template<typename T>
         void test_type() {
             auto epsilon = std::numeric_limits<T>::epsilon();


### PR DESCRIPTION
Move mathematical constants out of math_constants namespace