### PR TITLE
Type promotion in rounding unnecessarily over 64 bits

### DIFF
--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -95,4 +95,12 @@ namespace {
                         rounding_elastic_number<62, 0>{2}))), "cnl::rounding_elastic_number division");
 #endif
     }
+    
+    namespace test_assignment {
+        static constexpr auto a = rounding_elastic_number<24, -20>{0.4375};
+        static constexpr auto b = rounding_elastic_number<24, -20>{0.5};
+        static_assert(identical(rounding_elastic_number<48, -40>{0.21875}, a * b), "rounding_elastic_number multiplication");
+        static constexpr auto c = static_cast<rounding_elastic_number<24, -20>>(a * b);
+        static_assert(identical(rounding_elastic_number<24, -20>{0.21875}, c), "rounding_elastic_number assignment");
+    }
 }

--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -95,12 +95,10 @@ namespace {
                         rounding_elastic_number<62, 0>{2}))), "cnl::rounding_elastic_number division");
 #endif
     }
-    
-    namespace test_assignment {
-        static constexpr auto a = rounding_elastic_number<24, -20>{0.4375};
-        static constexpr auto b = rounding_elastic_number<24, -20>{0.5};
-        static_assert(identical(rounding_elastic_number<48, -40>{0.21875}, a * b), "rounding_elastic_number multiplication");
-        static constexpr auto c = static_cast<rounding_elastic_number<24, -20>>(a * b);
+
+    namespace test_static_cast {
+        static constexpr auto c = static_cast<rounding_elastic_number<24, -20>>(rounding_elastic_number<48, -40>{0.21875});
         static_assert(identical(rounding_elastic_number<24, -20>{0.21875}, c), "rounding_elastic_number assignment");
     }
+    
 }


### PR DESCRIPTION
Find a new test case in this pull request for a potential bug

With the code below I get the underlying integer type promoted to 68 bits, but I believe thatno larger than 48 bit integer type should be required to do the rounding from <48, -40) to <24, -20> type.
This test will catch only when compiling without 128 bit support.

If you agree, you should probably merge this test to bug fix branch of this issue rather than directly to develop.

```cpp
    namespace test_assignment {
        static constexpr auto a = rounding_elastic_number<24, -20>{0.4375};
        static constexpr auto b = rounding_elastic_number<24, -20>{0.5};
        static_assert(identical(rounding_elastic_number<48, -40>{0.21875}, a * b), "rounding_elastic_number multiplication");
        static constexpr auto c = static_cast<rounding_elastic_number<24, -20>>(a * b);
        static_assert(identical(rounding_elastic_number<24, -20>{0.21875}, c), "rounding_elastic_number assignment");
    }
```

```
error: implicit instantiation of undefined template 'cnl::signed_integer_cannot_have<68>::digits_because_maximum_is<63>'
                : signed_integer_cannot_have<MinNumDigits>::template digits_because_maximum_is<numeric_limits<intmax>::digits> 

...

note: in instantiation of function template specialization 'cnl::fixed_point<cnl::rounding_integer<cnl::elastic_integer<24, int>, cnl::_impl::nearest_rounding_tag>, -20, 2>::fixed_point<cnl::rounding_integer<cnl::elastic_integer<48, int>, cnl::_impl::nearest_rounding_tag>, -40>' requested here
        static constexpr auto c = static_cast<rounding_elastic_number<24, -20>>(a * b);
                                  
```