### PR TITLE
Move implementation of cnl::used_digits out of public API

### DIFF
--- a/include/cnl/auxiliary/boost.multiprecision.h
+++ b/include/cnl/auxiliary/boost.multiprecision.h
@@ -60,7 +60,10 @@ namespace cnl {
         static constexpr auto _bits = _digits + _is_signed;
         static constexpr auto _sign_type = _is_signed ? _bmp::signed_magnitude : _bmp::unsigned_magnitude;
     public:
-        using type = _bmp::cpp_int_backend<_bits, _bits, _sign_type, Checked, void>;
+        constexpr auto operator()(Value const& value) const
+        -> _bmp::cpp_int_backend<_bits, _bits, _sign_type, Checked, void> {
+            return value;
+        }
     };
 
     template<class Backend, _bmp::expression_template_option ExpressionTemplates>
@@ -85,7 +88,22 @@ namespace cnl {
 
     template<class Backend, _bmp::expression_template_option ExpressionTemplates, class Value>
     struct from_value<_bmp::number<Backend, ExpressionTemplates>, Value> {
-        using type = _bmp::number<from_value_t<Backend, Value>, ExpressionTemplates>;
+        constexpr auto operator()(Value const& value) const
+        -> _bmp::number<from_value_t<Backend, Value>, ExpressionTemplates> {
+            return value;
+        }
+    };
+
+    template<
+            class LhsBackend, _bmp::expression_template_option LhsExpressionTemplates,
+            class RhsBackend, _bmp::expression_template_option RhsExpressionTemplates>
+    struct from_value<
+            _bmp::number<LhsBackend, LhsExpressionTemplates>,
+            _bmp::number<RhsBackend, RhsExpressionTemplates>> {
+        constexpr auto operator()(_bmp::number<RhsBackend, RhsExpressionTemplates> const& value) const
+        -> _bmp::number<RhsBackend, LhsExpressionTemplates> {
+            return value;
+        }
     };
 
     template<int Digits, class Backend, _bmp::expression_template_option ExpressionTemplates>

--- a/include/cnl/bits/fixed_point/constants.h
+++ b/include/cnl/bits/fixed_point/constants.h
@@ -12,7 +12,7 @@
 
 #include "type.h"
 
-#include <cnl/numeric.h>
+#include <cnl/bits/used_digits.h>
 
 /// compositional numeric library
 namespace cnl {

--- a/include/cnl/bits/fixed_point/fractional.h
+++ b/include/cnl/bits/fixed_point/fractional.h
@@ -16,25 +16,6 @@
 
 /// compositional numeric library
 namespace cnl {
-    ////////////////////////////////////////////////////////////////////////////////
-    // cnl::make_fixed_point<cnl::fractional<>>
-
-    /// \brief makes a \ref fixed_point object from a given \ref fractional
-    ///
-    /// \tparam Numerator the type of the numerator of the fractional
-    /// \tparam Denominator the type of the denominator of the fractional
-    ///
-    /// \param value the fractionalfrom which to make the \ref fixed_point object
-    ///
-    /// \note This function is deprecated after C++17
-    /// in favor of class template deduction.
-    template<typename Numerator, typename Denominator>
-    constexpr auto make_fixed_point(fractional<Numerator, Denominator> const& value)
-    -> decltype(quotient(value.numerator, value.denominator))
-    {
-        return quotient(value.numerator, value.denominator);
-    }
-
     template<typename Rep, int Exponent, int Radix>
     template<typename Numerator, typename Denominator>
     constexpr fixed_point<Rep, Exponent, Radix>::fixed_point(fractional<Numerator, Denominator> const& f)

--- a/include/cnl/bits/fixed_point/num_traits.h
+++ b/include/cnl/bits/fixed_point/num_traits.h
@@ -71,19 +71,13 @@ namespace cnl {
     // cnl::from_value<cnl::fixed_point<>>
 
     template<typename Rep, int Exponent, int Radix, typename Value>
-    struct from_value<fixed_point<Rep, Exponent, Radix>, Value> {
-        constexpr auto operator()(Value const &value) const
-        -> fixed_point<Value, 0, Radix> {
-            return value;
-        }
+    struct from_value<fixed_point<Rep, Exponent, Radix>, Value>
+            : _impl::from_value_simple<Value, fixed_point<Value, 0, Radix>> {
     };
 
     template<typename Rep, int Exponent, int Radix, typename ValueRep, int ValueExponent>
-    struct from_value<fixed_point<Rep, Exponent, Radix>, fixed_point<ValueRep, ValueExponent>> {
-        constexpr auto operator()(fixed_point<ValueRep, ValueExponent> const& value) const
-        -> fixed_point<from_value_t<Rep, ValueRep>, ValueExponent> {
-            return value;
-        }
+    struct from_value<fixed_point<Rep, Exponent, Radix>, fixed_point<ValueRep, ValueExponent>> : _impl::from_value_simple<
+            fixed_point<ValueRep, ValueExponent>, fixed_point<from_value_t<Rep, ValueRep>, ValueExponent>> {
     };
 
     template<typename Rep, int Exponent, int Radix, typename Numerator, typename Denominator>
@@ -95,14 +89,11 @@ namespace cnl {
     };
 
     template<typename Rep, int Exponent, int Radix, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
-    struct from_value<fixed_point<Rep, Exponent, Radix>, constant<Value>> {
+    struct from_value<fixed_point<Rep, Exponent, Radix>, constant<Value>> : _impl::from_value_simple<constant<Value>,
+            fixed_point<
+                    set_digits_t<int, _impl::max(digits<int>::value, _impl::used_digits(Value)-trailing_bits(Value))>,
+                    trailing_bits(Value)>> {
         // same as deduction guide
-        constexpr auto operator()(constant<Value> const& value) const
-        -> fixed_point<
-                set_digits_t<int, _impl::max(digits<int>::value, _impl::used_digits(Value)-trailing_bits(Value))>,
-                trailing_bits(Value)> {
-            return value;
-        }
     };
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/cnl/bits/fixed_point/num_traits.h
+++ b/include/cnl/bits/fixed_point/num_traits.h
@@ -84,7 +84,7 @@ namespace cnl {
     struct from_value<fixed_point<Rep, Exponent, Radix>, constant<Value>> {
         // same as deduction guide
         using type = fixed_point<
-                set_digits_t<int, _impl::max(digits<int>::value, used_digits(Value)-trailing_bits(Value))>,
+                set_digits_t<int, _impl::max(digits<int>::value, _impl::used_digits(Value)-trailing_bits(Value))>,
                 trailing_bits(Value)>;
     };
 

--- a/include/cnl/bits/fixed_point/num_traits.h
+++ b/include/cnl/bits/fixed_point/num_traits.h
@@ -72,20 +72,37 @@ namespace cnl {
 
     template<typename Rep, int Exponent, int Radix, typename Value>
     struct from_value<fixed_point<Rep, Exponent, Radix>, Value> {
-        using type = fixed_point<Value, 0, Radix>;
+        constexpr auto operator()(Value const &value) const
+        -> fixed_point<Value, 0, Radix> {
+            return value;
+        }
     };
 
     template<typename Rep, int Exponent, int Radix, typename ValueRep, int ValueExponent>
     struct from_value<fixed_point<Rep, Exponent, Radix>, fixed_point<ValueRep, ValueExponent>> {
-        using type = fixed_point<from_value_t<Rep, ValueRep>, ValueExponent>;
+        constexpr auto operator()(fixed_point<ValueRep, ValueExponent> const& value) const
+        -> fixed_point<from_value_t<Rep, ValueRep>, ValueExponent> {
+            return value;
+        }
+    };
+
+    template<typename Rep, int Exponent, int Radix, typename Numerator, typename Denominator>
+    struct from_value<fixed_point<Rep, Exponent, Radix>, fractional<Numerator, Denominator>> {
+        constexpr auto operator()(fractional<Numerator, Denominator> const& value) const
+        -> decltype(quotient(value.numerator, value.denominator)) {
+            return quotient(value.numerator, value.denominator);
+        }
     };
 
     template<typename Rep, int Exponent, int Radix, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     struct from_value<fixed_point<Rep, Exponent, Radix>, constant<Value>> {
         // same as deduction guide
-        using type = fixed_point<
+        constexpr auto operator()(constant<Value> const& value) const
+        -> fixed_point<
                 set_digits_t<int, _impl::max(digits<int>::value, _impl::used_digits(Value)-trailing_bits(Value))>,
-                trailing_bits(Value)>;
+                trailing_bits(Value)> {
+            return value;
+        }
     };
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/cnl/bits/fixed_point/type.h
+++ b/include/cnl/bits/fixed_point/type.h
@@ -238,7 +238,9 @@ namespace cnl {
     // same as cnl::make_fixed_point
     template<CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     fixed_point(::cnl::constant<Value>)
-    -> fixed_point<set_digits_t<int, _impl::max(digits_v<int>, used_digits(Value)-trailing_bits(Value))>, trailing_bits(Value)>;
+    -> fixed_point<
+            set_digits_t<int, _impl::max(digits_v<int>, _impl::used_digits(Value)-trailing_bits(Value))>,
+            trailing_bits(Value)>;
 
     template<class Integer>
     fixed_point(Integer)

--- a/include/cnl/bits/rounding.h
+++ b/include/cnl/bits/rounding.h
@@ -78,7 +78,8 @@ namespace cnl {
             constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
             -> decltype(lhs >> rhs)
             {
-                return (lhs+((Lhs{1}<<rhs)>>1)) >> rhs;
+                return (lhs + ((static_cast<from_value_t<Lhs, constant<1>>>(constant<1>{}) << rhs) >> constant<1>{}))
+                        >> rhs;
             }
         };
 

--- a/include/cnl/bits/used_digits.h
+++ b/include/cnl/bits/used_digits.h
@@ -1,0 +1,65 @@
+
+//          Copyright John McFarlane 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef CNL_BITS_USED_DIGITS_H
+#define CNL_BITS_USED_DIGITS_H
+
+namespace cnl {
+    namespace _impl {
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // cnl::_impl::used_digits
+
+        template<typename Integer>
+        constexpr int used_digits_positive(Integer const& value, int radix)
+        {
+            static_assert(cnl::numeric_limits<Integer>::is_integer,
+                    "Integer parameter of used_digits_positive() must be a fundamental integer.");
+
+            return (value>0) ? 1+used_digits_positive(value/radix, radix) : 0;
+        }
+
+        template<bool IsSigned>
+        struct used_digits_signed {
+            template<class Integer>
+            constexpr int operator()(Integer const& value, int radix) const
+            {
+                return value ? used_digits_positive(value, radix) : 0;
+            }
+        };
+
+        template<>
+        struct used_digits_signed<true> {
+            template<class Integer>
+            constexpr int operator()(Integer const& value, int radix) const
+            {
+                static_assert(cnl::numeric_limits<Integer>::is_integer,
+                        "Integer parameter of used_digits_signed()() must be a fundamental integer.");
+
+                // Most negative number is not exploited;
+                // thus negating the result or subtracting it from something else
+                // will less likely result in overflow.
+                return (value>0)
+                       ? used_digits_positive(value, radix)
+                       : (value==0)
+                         ? 0
+                         : used_digits_signed()(Integer(-1)-value, radix);
+            }
+        };
+
+        template<typename Integer>
+        constexpr int used_digits(Integer const& value, int radix = numeric_limits<Integer>::radix)
+        {
+            static_assert(std::is_integral<Integer>::value
+                    || std::is_same<Integer, intmax>::value
+                    || std::is_same<Integer, uintmax>::value, "Integer must be a fundamental integral");
+
+            return used_digits_signed<std::is_signed<Integer>::value>{}(value, radix);
+        }
+    }
+}
+
+#endif  // CNL_BITS_USED_DIGITS_H

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -119,7 +119,7 @@ namespace cnl {
         using type = elastic_integer<cnl::digits<Value>::value, cnl::_impl::make_signed_t<Narrowest, cnl::is_signed<Value>::value>>;
     };
 
-    template<int Digits, class Narrowest, intmax Value>
+    template<int Digits, class Narrowest, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     struct from_value<elastic_integer<Digits, Narrowest>, constant<Value>> {
         static constexpr auto _to_digits = digits<constant<Value>>::value;
         using type = elastic_integer<_to_digits, Narrowest>;

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -122,7 +122,7 @@ namespace cnl {
     template<int Digits, class Narrowest, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     struct from_value<elastic_integer<Digits, Narrowest>, constant<Value>> {
         static constexpr auto _to_digits = digits<constant<Value>>::value;
-        using type = elastic_integer<_to_digits, Narrowest>;
+        using type = elastic_integer<_to_digits, int>;
     };
 
     // cnl::scale<..., cnl::elastic_integer<>>

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -11,7 +11,6 @@
 #define CNL_ELASTIC_INTEGER_H 1
 
 #include "constant.h"
-#include "numeric.h"
 
 #include "bits/number_base.h"
 

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -115,22 +115,16 @@ namespace cnl {
     };
 
     template<int Digits, class Narrowest, class Value>
-    struct from_value<elastic_integer<Digits, Narrowest>, Value> {
-        constexpr auto operator()(Value const& value) const
-        -> elastic_integer<
-                cnl::digits<Value>::value,
-                cnl::_impl::make_signed_t<Narrowest, cnl::is_signed<Value>::value>> {
-            return value;
-        }
+    struct from_value<elastic_integer<Digits, Narrowest>, Value>
+            : _impl::from_value_simple<Value, elastic_integer<
+                    cnl::digits<Value>::value,
+                    cnl::_impl::make_signed_t<Narrowest, cnl::is_signed<Value>::value>>> {
     };
 
     template<int Digits, class Narrowest, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
-    struct from_value<elastic_integer<Digits, Narrowest>, constant<Value>> {
-        static constexpr auto _to_digits = digits<constant<Value>>::value;
-        constexpr auto operator()(constant<Value> const& value) const
-        -> elastic_integer<_to_digits, int> {
-            return value;
-        }
+    struct from_value<elastic_integer<Digits, Narrowest>, constant<Value>> : _impl::from_value_simple<
+            constant<Value>,
+            elastic_integer<digits<constant<Value>>::value, int>> {
     };
 
     // cnl::scale<..., cnl::elastic_integer<>>

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -116,13 +116,21 @@ namespace cnl {
 
     template<int Digits, class Narrowest, class Value>
     struct from_value<elastic_integer<Digits, Narrowest>, Value> {
-        using type = elastic_integer<cnl::digits<Value>::value, cnl::_impl::make_signed_t<Narrowest, cnl::is_signed<Value>::value>>;
+        constexpr auto operator()(Value const& value) const
+        -> elastic_integer<
+                cnl::digits<Value>::value,
+                cnl::_impl::make_signed_t<Narrowest, cnl::is_signed<Value>::value>> {
+            return value;
+        }
     };
 
     template<int Digits, class Narrowest, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     struct from_value<elastic_integer<Digits, Narrowest>, constant<Value>> {
         static constexpr auto _to_digits = digits<constant<Value>>::value;
-        using type = elastic_integer<_to_digits, int>;
+        constexpr auto operator()(constant<Value> const& value) const
+        -> elastic_integer<_to_digits, int> {
+            return value;
+        }
     };
 
     // cnl::scale<..., cnl::elastic_integer<>>

--- a/include/cnl/integral_constant.h
+++ b/include/cnl/integral_constant.h
@@ -10,8 +10,6 @@
 #if !defined(CNL_INTEGRAL_CONSTANT_H)
 #define CNL_INTEGRAL_CONSTANT_H 1
 
-#include "numeric.h
-
 #include "bits/common.h"
 
 #include <cstdint>

--- a/include/cnl/num_traits.h
+++ b/include/cnl/num_traits.h
@@ -414,24 +414,6 @@ namespace cnl {
     ////////////////////////////////////////////////////////////////////////////////
     // cnl::from_value
 
-    namespace _num_traits_impl {
-        template<int Width, bool IsSigned>
-        struct make_integer;
-
-        template<int Width>
-        struct make_integer<Width, true> {
-            using type = set_digits_t<signed, Width-1>;
-        };
-
-        template<int Width>
-        struct make_integer<Width, false> {
-            using type = set_digits_t<unsigned, Width>;
-        };
-
-        template<int Width, bool IsSigned>
-        using make_integer_t = typename make_integer<Width, IsSigned>::type;
-    }
-
     // if Number has Value for its Rep, what type would Number become?
     template<class Number, class Value, class Enable = void>
     struct from_value {
@@ -443,7 +425,7 @@ namespace cnl {
         using type = typename std::conditional<
                 cnl::is_integral<Value>::value,
                 Value,
-                _num_traits_impl::make_integer_t<cnl::digits<Value>::value, cnl::is_signed<Value>::value>>::type;
+                set_digits_t<_impl::make_signed_t<int, cnl::is_signed<Value>::value>, cnl::digits<Value>::value>>::type;
     };
 
     template<class Number, class Value>

--- a/include/cnl/num_traits.h
+++ b/include/cnl/num_traits.h
@@ -414,23 +414,28 @@ namespace cnl {
     ////////////////////////////////////////////////////////////////////////////////
     // cnl::from_value
 
+    namespace _impl {
+        template<typename Value, typename Result>
+        struct from_value_simple {
+            constexpr Result operator()(Value const& value) const {
+                return value;
+            }
+        };
+    }
+
     template<typename Number, typename Value, class Enable = void>
-    struct from_value {
-        void operator()(Value const &) const {
-        }
+    struct from_value : _impl::from_value_simple<Value, void> {
+        void operator()(Value const &) const;
     };
 
     template<class Number, class Value>
-    struct from_value<Number, Value,
-            _impl::enable_if_t<cnl::is_integral<Number>::value && cnl::is_integral<Value>::value>> {
-        constexpr Value operator()(Value const &value) const {
-            return value;
-        }
+    struct from_value<
+            Number, Value, _impl::enable_if_t<cnl::is_integral<Number>::value && cnl::is_integral<Value>::value>>
+            : _impl::from_value_simple<Value, Value> {
     };
 
     template<class Number, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
-    struct from_value<Number, constant<Value>,
-            _impl::enable_if_t<is_integral<Number>::value>> {
+    struct from_value<Number, constant<Value>, _impl::enable_if_t<is_integral<Number>::value>> {
     private:
         using _result_type = set_digits_t<
                 make_signed_t<Number>,

--- a/include/cnl/num_traits.h
+++ b/include/cnl/num_traits.h
@@ -15,6 +15,7 @@
 
 #include "bits/power.h"
 #include "bits/type_traits.h"
+#include "bits/used_digits.h"
 
 #include <utility>
 
@@ -190,6 +191,15 @@ namespace cnl {
     template<class T>
     constexpr _digits_type digits_v = digits<T>::value;
 #endif
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // cnl::digits<cnl::constant<>>
+
+    template<CNL_IMPL_CONSTANT_VALUE_TYPE Value>
+    struct digits<constant<Value>> : std::integral_constant<
+            _digits_type,
+            _impl::used_digits((Value<0) ? -Value : Value)> {
+    };
 
     ////////////////////////////////////////////////////////////////////////////////
     // set_digits / set_digits_t

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -183,7 +183,10 @@ namespace cnl {
 
     template<class Rep, class OverflowTag, class Value>
     struct from_value<overflow_integer<Rep, OverflowTag>, Value> {
-        using type = overflow_integer<Value, OverflowTag>;
+        constexpr auto operator()(Value const &value) const
+        -> overflow_integer<Value, OverflowTag> {
+            return value;
+        }
     };
 
     template<class Rep, class OverflowTag, class ValueRep, class ValueOverflowTag>
@@ -193,13 +196,20 @@ namespace cnl {
         using _overflow_tag = _impl::common_type_t<OverflowTag, ValueOverflowTag>;
         using _rep = from_value_t<Rep, ValueRep>;
     public:
-        using type = overflow_integer<_rep, _overflow_tag>;
+        constexpr auto operator()(overflow_integer<ValueRep, ValueOverflowTag> const &value) const
+        -> overflow_integer<_rep, _overflow_tag> {
+            return value;
+        }
     };
 
     template<class Rep, class OverflowTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     struct from_value<overflow_integer<Rep, OverflowTag>, constant<Value>> {
         using _rep = typename std::conditional<digits<int>::value<_impl::used_digits(Value), decltype(Value), int>::type;
-        using type = overflow_integer<_rep, OverflowTag>;
+
+        constexpr auto operator()(constant<Value> const &value) const
+        -> overflow_integer<_rep, OverflowTag> {
+            return value;
+        }
     };
 
     template<int Digits, class Rep, class OverflowTag>

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -182,34 +182,23 @@ namespace cnl {
     };
 
     template<class Rep, class OverflowTag, class Value>
-    struct from_value<overflow_integer<Rep, OverflowTag>, Value> {
-        constexpr auto operator()(Value const &value) const
-        -> overflow_integer<Value, OverflowTag> {
-            return value;
-        }
+    struct from_value<overflow_integer<Rep, OverflowTag>, Value>
+            : _impl::from_value_simple<Value, overflow_integer<Value, OverflowTag>> {
     };
 
     template<class Rep, class OverflowTag, class ValueRep, class ValueOverflowTag>
-    struct from_value<overflow_integer<Rep, OverflowTag>, overflow_integer<ValueRep, ValueOverflowTag>> {
-    private:
-        // the common_type of two overflow tags is the stricter for some sense of strict
-        using _overflow_tag = _impl::common_type_t<OverflowTag, ValueOverflowTag>;
-        using _rep = from_value_t<Rep, ValueRep>;
-    public:
-        constexpr auto operator()(overflow_integer<ValueRep, ValueOverflowTag> const &value) const
-        -> overflow_integer<_rep, _overflow_tag> {
-            return value;
-        }
+    struct from_value<overflow_integer<Rep, OverflowTag>, overflow_integer<ValueRep, ValueOverflowTag>>
+            : _impl::from_value_simple<
+                    overflow_integer<ValueRep, ValueOverflowTag>,
+                    overflow_integer<
+                            from_value_t<Rep, ValueRep>,
+                            _impl::common_type_t<OverflowTag, ValueOverflowTag>>> {
     };
 
     template<class Rep, class OverflowTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
-    struct from_value<overflow_integer<Rep, OverflowTag>, constant<Value>> {
-        using _rep = typename std::conditional<digits<int>::value<_impl::used_digits(Value), decltype(Value), int>::type;
-
-        constexpr auto operator()(constant<Value> const &value) const
-        -> overflow_integer<_rep, OverflowTag> {
-            return value;
-        }
+    struct from_value<overflow_integer<Rep, OverflowTag>, constant<Value>>
+            : _impl::from_value_simple<constant<Value>, overflow_integer<typename std::conditional<
+                    digits<int>::value<_impl::used_digits(Value), decltype(Value), int>::type, OverflowTag>>{
     };
 
     template<int Digits, class Rep, class OverflowTag>

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -198,7 +198,7 @@ namespace cnl {
 
     template<class Rep, class OverflowTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     struct from_value<overflow_integer<Rep, OverflowTag>, constant<Value>> {
-        using _rep = typename std::conditional<digits<int>::value<used_digits(Value), decltype(Value), int>::type;
+        using _rep = typename std::conditional<digits<int>::value<_impl::used_digits(Value), decltype(Value), int>::type;
         using type = overflow_integer<_rep, OverflowTag>;
     };
 

--- a/include/cnl/rounding_integer.h
+++ b/include/cnl/rounding_integer.h
@@ -7,11 +7,9 @@
 #if !defined(CNL_ROUNDING_INTEGER_H)
 #define CNL_ROUNDING_INTEGER_H 1
 
-#include "numeric.h"
-
 #include "bits/number_base.h"
 #include "bits/rounding.h"
-
+#include "bits/used_digits.h"
 
 /// compositional numeric library
 namespace cnl {
@@ -121,7 +119,7 @@ namespace cnl {
 
     template<class Rep, class RoundingTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     struct from_value<rounding_integer<Rep, RoundingTag>, constant<Value>> {
-        using _rep = typename std::conditional<digits<int>::value<used_digits(Value),
+        using _rep = typename std::conditional<digits<int>::value<_impl::used_digits(Value),
                 decltype(Value),
                 int>::type;
         using type = rounding_integer<_rep, RoundingTag>;

--- a/include/cnl/rounding_integer.h
+++ b/include/cnl/rounding_integer.h
@@ -109,12 +109,18 @@ namespace cnl {
 
     template<class Rep, class RoundingTag, class Value>
     struct from_value<rounding_integer<Rep, RoundingTag>, Value> {
-        using type = rounding_integer<Value, RoundingTag>;
+        constexpr auto operator()(Value const &value) const
+        -> rounding_integer<Value, RoundingTag> {
+            return value;
+        }
     };
 
     template<class Rep, class RoundingTag, class ValueRep, class ValueRoundingTag>
     struct from_value<rounding_integer<Rep, RoundingTag>, rounding_integer<ValueRep, ValueRoundingTag>> {
-        using type = rounding_integer<ValueRep, RoundingTag>;
+        constexpr auto operator()(rounding_integer<ValueRep, ValueRoundingTag> const &value) const
+        -> rounding_integer<ValueRep, RoundingTag> {
+            return value;
+        }
     };
 
     template<class Rep, class RoundingTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
@@ -122,7 +128,11 @@ namespace cnl {
         using _rep = typename std::conditional<digits<int>::value<_impl::used_digits(Value),
                 decltype(Value),
                 int>::type;
-        using type = rounding_integer<_rep, RoundingTag>;
+
+        constexpr auto operator()(constant<Value> const &value) const
+        -> rounding_integer<_rep, RoundingTag> {
+            return value;
+        }
     };
 
     template<int Digits, class Rep, class RoundingTag>

--- a/include/cnl/rounding_integer.h
+++ b/include/cnl/rounding_integer.h
@@ -108,31 +108,22 @@ namespace cnl {
     }
 
     template<class Rep, class RoundingTag, class Value>
-    struct from_value<rounding_integer<Rep, RoundingTag>, Value> {
-        constexpr auto operator()(Value const &value) const
-        -> rounding_integer<Value, RoundingTag> {
-            return value;
-        }
+    struct from_value<rounding_integer<Rep, RoundingTag>, Value> : _impl::from_value_simple<
+            Value, rounding_integer<Value, RoundingTag>> {
     };
 
     template<class Rep, class RoundingTag, class ValueRep, class ValueRoundingTag>
-    struct from_value<rounding_integer<Rep, RoundingTag>, rounding_integer<ValueRep, ValueRoundingTag>> {
-        constexpr auto operator()(rounding_integer<ValueRep, ValueRoundingTag> const &value) const
-        -> rounding_integer<ValueRep, RoundingTag> {
-            return value;
-        }
+    struct from_value<rounding_integer<Rep, RoundingTag>, rounding_integer<ValueRep, ValueRoundingTag>>
+            : _impl::from_value_simple<
+            rounding_integer<ValueRep, ValueRoundingTag>, rounding_integer<ValueRep, RoundingTag>> {
     };
 
     template<class Rep, class RoundingTag, CNL_IMPL_CONSTANT_VALUE_TYPE Value>
-    struct from_value<rounding_integer<Rep, RoundingTag>, constant<Value>> {
-        using _rep = typename std::conditional<digits<int>::value<_impl::used_digits(Value),
-                decltype(Value),
-                int>::type;
-
-        constexpr auto operator()(constant<Value> const &value) const
-        -> rounding_integer<_rep, RoundingTag> {
-            return value;
-        }
+    struct from_value<rounding_integer<Rep, RoundingTag>, constant<Value>> : _impl::from_value_simple<
+            constant<Value>, rounding_integer<typename std::conditional<
+                    digits<int>::value<_impl::used_digits(Value),
+                    decltype(Value),
+                    int>::type, RoundingTag>> {
     };
 
     template<int Digits, class Rep, class RoundingTag>

--- a/include/cnl/static_number.h
+++ b/include/cnl/static_number.h
@@ -56,7 +56,7 @@ namespace cnl {
             class Input = int,
             CNL_IMPL_CONSTANT_VALUE_TYPE Value>
     static_number<
-            used_digits(Value)-trailing_bits(Value), trailing_bits(Value),
+            _impl::used_digits(Value)-trailing_bits(Value), trailing_bits(Value),
             RoundingTag, OverflowTag,
             Narrowest>
     constexpr make_static_number(constant<Value> const&)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -5,7 +5,7 @@ enable_testing()
 # source files containing tests of the correctness of CNL;
 # ideally compiles with every warning that CNL user might choose
 set(test_sources
-        # low-level
+        # free functions
         bit.cpp
         cnlint.cpp
         common.cpp
@@ -27,6 +27,9 @@ set(test_sources
         fixed_point/extras.cpp
         overflow/overflow_integer.cpp
         rounding/rounding_integer.cpp
+
+        # components in free functions
+        elastic/rounding/elastic_integer_rounding.cpp
 
         # composites
         fixed_point/overflow/fixed_point_native_integer.cpp

--- a/src/test/elastic/elastic_integer.cpp
+++ b/src/test/elastic/elastic_integer.cpp
@@ -122,11 +122,21 @@ namespace {
         using cnl::from_value;
 
         static_assert(std::is_same<elastic_integer<7, int>::rep, int>::value, "");
-        static_assert(identical(cnl::from_value<elastic_integer<3>, int>::type{1},
-                                elastic_integer<cnl::numeric_limits<int>::digits>{1}), "elastic_integer test failed");
+        static_assert(identical(
+                elastic_integer<cnl::numeric_limits<int>::digits>{1},
+                cnl::_impl::from_value<elastic_integer<3>>(1)), "elastic_integer test failed");
         static_assert(identical(cnl::_impl::from_value<elastic_integer<3>>(1),
                 elastic_integer<cnl::numeric_limits<int>::digits>{1}), "elastic_integer test failed");
         static_assert(identical(cnl::_impl::from_value<elastic_integer<1>>(INT32_C(0)), elastic_integer<31>{0}), "cnl::elastic_integer test failed");
+
+        static_assert(identical(
+                cnl::elastic_integer<3, signed>{6},
+                cnl::_impl::from_value<cnl::elastic_integer<2, unsigned>>(cnl::constant<6>{})),
+                "from_value<elastic_integer, constant>");
+        static_assert(identical(
+                cnl::elastic_integer<3, signed>{6},
+                cnl::_impl::from_value<cnl::elastic_integer<2, signed>>(cnl::constant<6>{})),
+                "from_value<elastic_integer, constant>");
     }
 
     namespace test_ctor {

--- a/src/test/elastic/elastic_integer.cpp
+++ b/src/test/elastic/elastic_integer.cpp
@@ -8,6 +8,7 @@
 /// \brief file containing tests of the `cnl::elastic_integer` type
 
 #include <cnl/elastic_integer.h>
+#include <cnl/numeric.h>
 #include <cnl/bits/rounding.h>
 
 #include <gtest/gtest.h>

--- a/src/test/elastic/rounding/elastic_integer_rounding.cpp
+++ b/src/test/elastic/rounding/elastic_integer_rounding.cpp
@@ -1,0 +1,32 @@
+
+//          Copyright John McFarlane 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cnl/elastic_integer.h>
+#include <cnl/rounding.h>
+
+namespace {
+    using cnl::_impl::identical;
+
+    namespace test_shift_right_nearest {
+        static_assert(
+                identical(
+                        cnl::elastic_integer<53>{14},
+                        cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<62>, cnl::constant<9>>{}(
+                                7000,
+                                cnl::constant<9>{})),
+                "shift_right(elastic_integer)");
+
+#if defined(CNL_INT128_ENABLED)
+        static_assert(
+                identical(
+                        cnl::elastic_integer<117>{14},
+                        cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<126>, cnl::constant<9>>{}(
+                                7000,
+                                cnl::constant<9>{})),
+                "shift_right(elastic_integer)");
+#endif
+    }
+}

--- a/src/test/elastic/rounding/overflow/rounding_safe_integer.cpp
+++ b/src/test/elastic/rounding/overflow/rounding_safe_integer.cpp
@@ -47,7 +47,7 @@ namespace cnl {
             class Narrowest = int,
             CNL_IMPL_CONSTANT_VALUE_TYPE InputValue = 0>
     rounding_safe_int<
-            used_digits(InputValue),
+            _impl::used_digits(InputValue),
             OverflowTag, RoundingTag,
             Narrowest>
     constexpr make_rounding_safe_int(constant<InputValue>)

--- a/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
+++ b/src/test/fixed_point/elastic/rounding/rounding_elastic_number.cpp
@@ -95,4 +95,10 @@ namespace {
                         rounding_elastic_number<62, 0>{2}))), "cnl::rounding_elastic_number division");
 #endif
     }
+
+    namespace test_static_cast {
+        static constexpr auto c = static_cast<rounding_elastic_number<24, -20>>(
+                rounding_elastic_number<48, -40>{0.21875});
+        static_assert(identical(rounding_elastic_number<24, -20>{0.21875}, c), "rounding_elastic_number assignment");
+    }
 }

--- a/src/test/fixed_point/fixed_point_common.h
+++ b/src/test/fixed_point/fixed_point_common.h
@@ -948,7 +948,6 @@ static_assert(static_cast<float>(sqrt(fixed_point<int32, -24>(3.141592654)))<1.7
 // std::leading_bits<fixed_point>
 
 namespace test_used_digits {
-    static_assert(cnl::used_digits(uint8{10})==4, "cnl::used_digits");
     static_assert(cnl::used_digits(fixed_point<uint8, -4>{1}) == 5, "cnl::used_digits");
     static_assert(cnl::used_digits(fixed_point<uint8, -3>{2}) == 5, "cnl::used_digits");
 }

--- a/src/test/num_traits.cpp
+++ b/src/test/num_traits.cpp
@@ -39,6 +39,36 @@ namespace {
         static_assert(identical(cnl::_impl::from_value<long long>(123LL), 123LL), "cnl::_impl::from_value<cnl::uint8>");
         static_assert(identical(cnl::_impl::from_value<long>(123L), 123L), "cnl::_impl::from_value<cnl::uint8>");
         static_assert(identical(cnl::_impl::from_value<long long>(123L), 123L), "cnl::_impl::from_value<cnl::uint8>");
+
+        static_assert(identical(std::int16_t{123}, cnl::_impl::from_value<std::int16_t>(std::int16_t{123})),
+                "cnl::_impl::from_value<std::int16_t, std::int16_t>");
+        static_assert(identical(std::int32_t{123}, cnl::_impl::from_value<std::int16_t>(std::int32_t{123})),
+                "cnl::_impl::from_value<std::int16_t, std::int32_t>");
+        static_assert(identical(std::int64_t{123}, cnl::_impl::from_value<std::int16_t>(std::int64_t{123})),
+                "cnl::_impl::from_value<std::int16_t, std::int64_t>");
+        static_assert(identical(std::int16_t{123}, cnl::_impl::from_value<std::int32_t>(std::int16_t{123})),
+                "cnl::_impl::from_value<std::int32_t, std::int16_t>");
+        static_assert(identical(std::int32_t{123}, cnl::_impl::from_value<std::int32_t>(std::int32_t{123})),
+                "cnl::_impl::from_value<std::int32_t, std::int32_t>");
+        static_assert(identical(std::int64_t{123}, cnl::_impl::from_value<std::int32_t>(std::int64_t{123})),
+                "cnl::_impl::from_value<std::int32_t, std::int64_t>");
+        static_assert(identical(std::int16_t{123}, cnl::_impl::from_value<std::int64_t>(std::int16_t{123})),
+                "cnl::_impl::from_value<std::int64_t, std::int16_t>");
+        static_assert(identical(std::int32_t{123}, cnl::_impl::from_value<std::int64_t>(std::int32_t{123})),
+                "cnl::_impl::from_value<std::int64_t, std::int32_t>");
+        static_assert(identical(std::int64_t{123}, cnl::_impl::from_value<std::int64_t>(std::int64_t{123})),
+                "cnl::_impl::from_value<std::int64_t, std::int64_t>");
+
+        // assumes that int === int32_t
+        static_assert(identical(123, cnl::_impl::from_value<std::int16_t>(cnl::constant<123>{})),
+                "cnl::_impl::from_value<std::int16_t, cnl::constant<std::int64_t>>");
+        static_assert(identical(123, cnl::_impl::from_value<std::int64_t>(cnl::constant<123>{})),
+                "cnl::_impl::from_value<std::int64_t, cnl::constant<std::int64_t>>");
+        static_assert(
+                identical(
+                        INT64_C(0x123456789abcdef),
+                        cnl::_impl::from_value<std::int16_t>(cnl::constant<0x123456789abcdef>{})),
+                "cnl::_impl::from_value<std::int16_t, cnl::constant<std::int64_t>>");
     }
 
     namespace test_set_digits {

--- a/src/test/numeric.cpp
+++ b/src/test/numeric.cpp
@@ -71,106 +71,106 @@ namespace {
 
     namespace test_numeric_impl {
         namespace test_used_digits_positive {
-            static_assert(_numeric_impl::used_digits_positive(1, 2)==1,
-                    "cnl::_numeric_impl::used_digits_positive test failed");
-            static_assert(_numeric_impl::used_digits_positive(2, 2)==2,
-                    "cnl::_numeric_impl::used_digits_positive test failed");
-            static_assert(_numeric_impl::used_digits_positive(uint8_t{255}, 2)==8,
-                    "cnl::_numeric_impl::used_digits_positive test failed");
-            static_assert(_numeric_impl::used_digits_positive(int16_t{32767}, 2)==15,
-                    "cnl::_numeric_impl::used_digits_positive test failed");
-            static_assert(_numeric_impl::used_digits_positive(numeric_limits<int64_t>::max(), 2)==63,
-                    "cnl::_numeric_impl::used_digits_positive test failed");
-            static_assert(_numeric_impl::used_digits_positive(numeric_limits<uint64_t>::max(), 2)==64,
-                    "cnl::_numeric_impl::used_digits_positive test failed");
+            static_assert(_impl::used_digits_positive(1, 2)==1,
+                    "cnl::_impl::used_digits_positive test failed");
+            static_assert(_impl::used_digits_positive(2, 2)==2,
+                    "cnl::_impl::used_digits_positive test failed");
+            static_assert(_impl::used_digits_positive(uint8_t{255}, 2)==8,
+                    "cnl::_impl::used_digits_positive test failed");
+            static_assert(_impl::used_digits_positive(int16_t{32767}, 2)==15,
+                    "cnl::_impl::used_digits_positive test failed");
+            static_assert(_impl::used_digits_positive(numeric_limits<int64_t>::max(), 2)==63,
+                    "cnl::_impl::used_digits_positive test failed");
+            static_assert(_impl::used_digits_positive(numeric_limits<uint64_t>::max(), 2)==64,
+                    "cnl::_impl::used_digits_positive test failed");
         }
     }
 
     namespace test_used_digits_2 {
-        static_assert(cnl::used_digits(0)==0, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(1)==1, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(2)==2, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(uint8_t{255})==8, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int16_t{32767})==15, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-1})==0, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-2})==1, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-3})==2, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-4})==2, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-5})==3, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-8})==3, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-9})==4, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-128})==7, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::lowest())==63,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::lowest()+1)==63,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::min()+1)==63,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::max())==63,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(UINT64_C(0))==0,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<uint64_t>::min())==0,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<uint64_t>::max())==64,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(INT64_C(0x7fffffff00000000))==63,
-                "cnl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(0)==0, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(1)==1, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(2)==2, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(uint8_t{255})==8, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int16_t{32767})==15, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-1})==0, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-2})==1, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-3})==2, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-4})==2, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-5})==3, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-8})==3, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-9})==4, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-128})==7, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::lowest())==63,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::lowest()+1)==63,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::min()+1)==63,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::max())==63,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(UINT64_C(0))==0,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<uint64_t>::min())==0,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<uint64_t>::max())==64,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(INT64_C(0x7fffffff00000000))==63,
+                "cnl::_impl::used_digits test failed");
 #if defined(CNL_INT128_ENABLED)
-        static_assert(cnl::used_digits(CNL_INTMAX_C(0x7fffffff000000000000000000000000))==127,
-                "cnl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(CNL_INTMAX_C(0x7fffffff000000000000000000000000))==127,
+                "cnl::_impl::used_digits test failed");
 #endif
     }
 
     namespace test_used_digits_10 {
-        static_assert(cnl::used_digits(0, 10)==0, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(1, 10)==1, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(9, 10)==1, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(10, 10)==2, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(99, 10)==2, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(100, 10)==3, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-1}, 10)==0, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-2}, 10)==1, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-10}, 10)==1, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-11}, 10)==2, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-100}, 10)==2, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(int8_t{-101}, 10)==3, "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::lowest(), 10)==19,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::lowest()+1, 10)==19,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::min()+1, 10)==19,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<int64_t>::max(), 10)==19,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(UINT64_C(0), 10)==0,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<uint64_t>::min(), 10)==0,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(numeric_limits<uint64_t>::max(), 10)==20,
-                "cnl::used_digits test failed");
-        static_assert(cnl::used_digits(INT64_C(0x7fffffff00000000), 10)==19,
-                "cnl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(0, 10)==0, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(1, 10)==1, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(9, 10)==1, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(10, 10)==2, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(99, 10)==2, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(100, 10)==3, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-1}, 10)==0, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-2}, 10)==1, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-10}, 10)==1, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-11}, 10)==2, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-100}, 10)==2, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(int8_t{-101}, 10)==3, "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::lowest(), 10)==19,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::lowest()+1, 10)==19,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::min()+1, 10)==19,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<int64_t>::max(), 10)==19,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(UINT64_C(0), 10)==0,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<uint64_t>::min(), 10)==0,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(numeric_limits<uint64_t>::max(), 10)==20,
+                "cnl::_impl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(INT64_C(0x7fffffff00000000), 10)==19,
+                "cnl::_impl::used_digits test failed");
 #if defined(CNL_INT128_ENABLED)
-        static_assert(cnl::used_digits(CNL_INTMAX_C(0x7fffffff000000000000000000000000), 10)==39,
-                "cnl::used_digits test failed");
+        static_assert(cnl::_impl::used_digits(CNL_INTMAX_C(0x7fffffff000000000000000000000000), 10)==39,
+                "cnl::_impl::used_digits test failed");
 #endif
     }
 
     namespace test_used_digits_n {
         template<int Radix>
         struct test_used_digits {
-            static_assert(cnl::used_digits(-Radix*Radix-1, Radix)==3, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(-Radix*Radix, Radix)==2, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(-Radix-1, Radix)==2, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(-Radix, Radix)==1, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(-1, Radix)==0, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(0, Radix)==0, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(1, Radix)==1, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(Radix-1, Radix)==1, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(Radix, Radix)==2, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(Radix*Radix-1, Radix)==2, "cnl::used_digits<10> test failed");
-            static_assert(cnl::used_digits(Radix*Radix, Radix)==3, "cnl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(-Radix*Radix-1, Radix)==3, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(-Radix*Radix, Radix)==2, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(-Radix-1, Radix)==2, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(-Radix, Radix)==1, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(-1, Radix)==0, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(0, Radix)==0, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(1, Radix)==1, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(Radix-1, Radix)==1, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(Radix, Radix)==2, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(Radix*Radix-1, Radix)==2, "cnl::_impl::used_digits<10> test failed");
+            static_assert(cnl::_impl::used_digits(Radix*Radix, Radix)==3, "cnl::_impl::used_digits<10> test failed");
         };
 
         template

--- a/src/test/papers/p0675.cpp
+++ b/src/test/papers/p0675.cpp
@@ -75,11 +75,6 @@ namespace cnl {
     using acme::smart_integer;
     template<class Rep>
     struct numeric_limits<smart_integer<Rep>> : numeric_limits<Rep> {};
-
-    template<class Rep, class Value>
-    struct from_value<smart_integer<Rep>, Value> {
-        using type = smart_integer<Value>;
-    };
 }
 
 namespace {

--- a/src/test/vc.cpp
+++ b/src/test/vc.cpp
@@ -12,19 +12,12 @@ namespace std {
 
 namespace cnl {
     template<typename T, class Abi, class Value>
-    struct from_value<Vc::simd<T, Abi>, Value> {
-        constexpr auto operator()(Value const &value) const
-        -> Vc::simd<Value, Abi> {
-            return value;
-        }
+    struct from_value<Vc::simd<T, Abi>, Value> : _impl::from_value_simple<Value, Vc::simd<Value, Abi>> {
     };
 
     template<typename ToT, class FromT, class Abi>
-    struct from_value<Vc::simd<ToT, Abi>, Vc::simd<FromT, Abi>> {
-        constexpr auto operator()(Vc::simd<FromT, Abi> const& value) const
-        -> Vc::simd<ToT, Abi> {
-            return value;
-        }
+    struct from_value<Vc::simd<ToT, Abi>, Vc::simd<FromT, Abi>> : _impl::from_value_simple<
+            Vc::simd<FromT, Abi>, Vc::simd<ToT, Abi>> {
     };
 
     template<int Digits, typename T, class Abi>

--- a/src/test/vc.cpp
+++ b/src/test/vc.cpp
@@ -13,12 +13,18 @@ namespace std {
 namespace cnl {
     template<typename T, class Abi, class Value>
     struct from_value<Vc::simd<T, Abi>, Value> {
-        using type = Vc::simd<Value, Abi>;
+        constexpr auto operator()(Value const &value) const
+        -> Vc::simd<Value, Abi> {
+            return value;
+        }
     };
 
     template<typename ToT, class FromT, class Abi>
     struct from_value<Vc::simd<ToT, Abi>, Vc::simd<FromT, Abi>> {
-        using type = Vc::simd<ToT, Abi>;
+        constexpr auto operator()(Vc::simd<FromT, Abi> const& value) const
+        -> Vc::simd<ToT, Abi> {
+            return value;
+        }
     };
 
     template<int Digits, typename T, class Abi>


### PR DESCRIPTION
addresses test failure in #232 and towards #187 