### PR TITLE
Added conversions and tests for cnl/_impl/rounding/convert.h

### DIFF
--- a/include/cnl/_impl/rounding/convert.h
+++ b/include/cnl/_impl/rounding/convert.h
@@ -31,6 +31,39 @@ namespace cnl {
             return static_cast<Result>(from+((from>=0) ? .5 : -.5));
         }
     };
+
+    template<typename Result, typename Input>
+    struct convert<
+           _impl::nearest_rounding_tag, Result, Input,
+           _impl::enable_if_t<
+                   std::is_floating_point<Result>::value && std::is_floating_point<Input>::value >> {
+        constexpr Result operator()(Input const& from) const
+        {
+            return static_cast<Result>(from);
+        }
+    };
+
+    template<typename Result, typename Input>
+    struct convert<
+           _impl::nearest_rounding_tag, Result, Input,
+           _impl::enable_if_t<
+                   cnl::numeric_limits<Result>::is_integer && cnl::numeric_limits<Input>::is_integer >> {
+        constexpr Result operator()(Input const& from) const
+        {
+            return static_cast<Result>(from);
+        }
+    };
+
+    template<typename Result, typename Input>
+    struct convert<
+           _impl::nearest_rounding_tag, Result, Input,
+           _impl::enable_if_t<
+                   std::is_floating_point<Result>::value && cnl::numeric_limits<Input>::is_integer >> {
+        constexpr Result operator()(Input const& from) const
+        {
+            return static_cast<Result>(from);
+        }
+    };
 }
 
 #endif  // CNL_IMPL_ROUNDING_CONVERT_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(test_sources
         overflow/overflow.cpp
         rounding/rounding.cpp
         _impl/num_traits/max_digits.cpp
+        _impl/rounding/convert.cpp
 
         # components
         constant.cpp

--- a/src/test/_impl/rounding/convert.cpp
+++ b/src/test/_impl/rounding/convert.cpp
@@ -1,0 +1,80 @@
+//          Copyright Heikki Berg 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file
+/// \brief tests for <cnl/_impl/rounding/convert.h>
+
+#include <cnl/_impl/rounding/convert.h>
+#include <cnl/_impl/type_traits/assert_same.h>
+#include <cnl/_impl/type_traits/identical.h>
+#include <cnl/elastic_number.h>
+#include <cnl/fixed_point.h>
+
+
+using cnl::_impl::assert_same;
+using cnl::_impl::identical;
+
+
+namespace  test_convert_nearest_rounding_native_datatypes
+{
+
+    static_assert(cnl::_impl::identical(0.123f,
+        cnl::convert<cnl::nearest_rounding_tag, float, float>{}(0.123f)),
+        "cnl::convert<nearest_rounding_tag, float, float>");
+
+    static_assert(cnl::_impl::identical(0.125,
+        cnl::convert<cnl::nearest_rounding_tag, double, float>{}(0.125f)),
+            "cnl::convert<nearest_rounding_tag, double, float>");
+
+    static_assert(cnl::_impl::identical(0,
+        cnl::convert<cnl::nearest_rounding_tag, int, float>{}(0.125f)),
+            "cnl::convert<nearest_rounding_tag, int, float>");
+
+    static_assert(cnl::_impl::identical(1,
+        cnl::convert<cnl::nearest_rounding_tag, int, float>{}(0.725f)),
+            "cnl::convert<nearest_rounding_tag, int, float>");
+
+    static_assert(cnl::_impl::identical(-1,
+        cnl::convert<cnl::nearest_rounding_tag, int, float>{}(-0.725f)),
+            "cnl::convert<nearest_rounding_tag, int, float>");
+
+    static_assert(cnl::_impl::identical(3,
+        cnl::convert<cnl::nearest_rounding_tag, int, int>{}(3)),
+            "cnl::convert<nearest_rounding_tag, int, int>");
+
+    static_assert(cnl::_impl::identical(3L,
+        cnl::convert<cnl::nearest_rounding_tag, long, int>{}(3)),
+        "cnl::convert<nearest_rounding_tag, long, int>");
+
+    static_assert(cnl::_impl::identical(3.0,
+        cnl::convert<cnl::nearest_rounding_tag, double, int>{}(3)),
+            "cnl::convert<nearest_rounding_tag, double, int>");
+}
+
+namespace test_convert_nearest_rounding_elastic_number
+{
+    static constexpr auto a = cnl::elastic_number<8, -4>{0.3125};
+    static constexpr auto b = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -1>, cnl::elastic_number<8, -4>>{}(a);
+    static_assert(identical(cnl::elastic_number<4, -1>{0.5}, b),
+        "cnl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
+
+    static constexpr auto c = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -2>, cnl::elastic_number<8, -4>>{}(a);
+    static_assert(identical(cnl::elastic_number<4, -2>{0.25}, c),
+        "cnl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
+}
+
+namespace test_convert_nearest_rounding_fixed_point
+{
+    static constexpr auto a = cnl::fixed_point<int, -4>{0.3125};
+    static constexpr auto b = cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -1>, cnl::fixed_point<int, -4>>{}(a);
+    static_assert(identical(cnl::fixed_point<int, -1>{0.5}, b),
+        "cnl::convert<nearest_rounding_tag, fixed_point, fixed_point>");
+
+    static constexpr auto c = cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -2>, cnl::fixed_point<int, -4>>{}(a);
+    static_assert(identical(cnl::fixed_point<int, -2>{0.25}, c),
+        "cnl::convert<nearest_rounding_tag, fixed_point, fixed_point>");
+}
+
+


### PR DESCRIPTION
@hbe72 given how horrendous the SFINAE logic is in this version, the three-specialization version starts to look pretty good! Otherwise all looks good. Thanks