### PR TITLE
Reinstate overflow_integer default constructor

### DIFF
--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -63,7 +63,7 @@ namespace cnl {
         ////////////////////////////////////////////////////////////////////////////////
         // functions
 
-        overflow_integer() = delete;
+        overflow_integer() = default;
 
         template<class RhsRep, class RhsOverflowTag>
         constexpr overflow_integer(overflow_integer<RhsRep, RhsOverflowTag> const& rhs)


### PR DESCRIPTION
- default-initialization isn't the concern of an integer type with
  "overflow" in the name
  - this is the same reason divide-by-zero isn't handled by this type

Addresses #240 