### PR TITLE
log errors on circle-ci ctest failures

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -9,5 +9,5 @@ apt-get install -y $1 cmake libboost-dev
 cmake -DCMAKE_BUILD_TYPE=Release -DINT128=$2 -DSTD=$3 /root/project
 cmake --build . -- -j 8 Tests Benchmark
 
-ctest -j 4
+ctest --output-on-failure -j 4
 src/benchmark/Benchmark

--- a/include/cnl/_impl/fixed_point/extras.h
+++ b/include/cnl/_impl/fixed_point/extras.h
@@ -16,7 +16,7 @@
 #include "../cmath/abs.h"
 #include "../num_traits/fixed_width_scale.h"
 #include "../num_traits/unwrap.h"
-#include "../terminate.h"
+#include "../unreachable.h"
 
 #include <cmath>
 #include <istream>
@@ -101,7 +101,7 @@ namespace cnl {
     {
         using type = fixed_point<Rep, Exponent, Radix>;
         return _impl::to_rep(x)<0
-               ? _impl::terminate<type>("negative value passed to cnl::sqrt")
+               ? _impl::unreachable<type>("negative value passed to cnl::sqrt")
                : type{_impl::from_rep<type>(_impl::sqrt_solve1<Exponent>{}(unwrap(x)))};
     }
 

--- a/src/test/fixed_point/fixed_point_common.h
+++ b/src/test/fixed_point/fixed_point_common.h
@@ -163,7 +163,7 @@ TEST(TOKENPASTE2(TEST_LABEL, post), decrement)
 ////////////////////////////////////////////////////////////////////////////////
 // sqrt exception throwing
 
-#if defined(CNL_EXCEPTIONS_ENABLED)
+#if defined(CNL_EXCEPTIONS_ENABLED) && !defined(CNL_UNREACHABLE_UB_ENABLED)
 
 TEST(TOKENPASTE2(TEST_LABEL, sqrt_exception), from_alternative_specialization)
 {

--- a/src/test/fixed_point/overflow/fixed_point_trapping_integer.cpp
+++ b/src/test/fixed_point/overflow/fixed_point_trapping_integer.cpp
@@ -23,6 +23,7 @@ using test_int = cnl::overflow_integer<int, cnl::trapping_overflow_tag>;
 ////////////////////////////////////////////////////////////////////////////////
 // trapping_integer-specific exceptions tests
 
+#if !defined(CNL_UNREACHABLE_UB_ENABLED)
 TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), scale_down)
 {
     auto scale_down_fn = cnl::_impl::scale<-8, 2, uint16>;
@@ -40,3 +41,4 @@ TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), assignment)
     using fp_type = fixed_point<int8, -7>;
     ASSERT_DEATH(fp_type(1), "positive overflow");
 }
+#endif

--- a/src/test/overflow/overflow.cpp
+++ b/src/test/overflow/overflow.cpp
@@ -526,11 +526,13 @@ namespace {
                         cnl::shift_left(cnl::trapping_overflow, -1073741824, 1)),
                 "cnl::shift_left with negative input");
 
+#if !defined(CNL_UNREACHABLE_UB_ENABLED)
         TEST(overflow, trap)
         {
             ASSERT_DEATH(
                     cnl::shift_left(cnl::trapping_overflow, -1073741825, 1),
                     "negative overflow");
         }
+#endif
     }
 }


### PR DESCRIPTION
- to help diagnose test failures during CI