### PR TITLE
abs should return same type as input parameter

### DIFF
--- a/include/cnl/_impl/cmath/abs.h
+++ b/include/cnl/_impl/cmath/abs.h
@@ -14,18 +14,18 @@ namespace cnl {
     namespace _impl {
         template<typename T>
         constexpr auto abs(T const& value)
-        -> enable_if_t<is_signed<T>::value, decltype(+value)>
+        -> enable_if_t<is_signed<T>::value, T>
         {
             static_assert(
                     std::is_same<decltype(+value), decltype(-value)>::value,
                     "cnl::abs only supports types with symetrically-typed unary operators");
 
-            return (value<0) ? -value : +value;
+            return static_cast<T>((value<0) ? -value : +value);
         }
 
         template<typename T>
         constexpr auto abs(T const& value)
-        -> enable_if_t<!is_signed<T>::value, decltype(+value)>
+        -> enable_if_t<!is_signed<T>::value, T>
         {
             return value;
         }

--- a/src/test/fraction.cpp
+++ b/src/test/fraction.cpp
@@ -174,7 +174,7 @@ namespace {
 
     namespace test_abs {
         static_assert(identical(
-                cnl::make_fraction(1024, 360L),
+                cnl::make_fraction(short{1024}, long{360}),
                 cnl::abs(cnl::make_fraction(short{1024}, long{360}))), "reduce(cnl::fraction)");
         static_assert(identical(
                 cnl::fraction<>(6, 3),


### PR DESCRIPTION
- makes things slightly easier to reason about
- may turn out to be a bad idea, e.g.
  cnl::abs((signed char)-128)