### PR TITLE
Use scale() to truncate fixed_point values for to_chars calculations.

### DIFF
--- a/include/cnl/_impl/fixed_point/to_chars.h
+++ b/include/cnl/_impl/fixed_point/to_chars.h
@@ -38,32 +38,11 @@ namespace cnl {
             static constexpr auto value = _sign_chars + _integer_chars + _radix_chars + _fractional_chars;
         };
 
-        template<typename FixedPoint, class Enable = void>
-        struct trunc_fn;
-
         template<typename Rep, int Exponent, int Radix>
-        struct trunc_fn<fixed_point<Rep, Exponent, Radix>, enable_if_t<(Exponent<0)>> {
-            constexpr auto operator()(fixed_point<Rep, Exponent, Radix> const& input) const
-            -> decltype(to_rep(input) >> -Exponent)
-            {
-                return to_rep(input) >> -Exponent;
-            }
-        };
-
-        template<typename Rep, int Exponent, int Radix>
-        struct trunc_fn<fixed_point<Rep, Exponent, Radix>, enable_if_t<!(Exponent<0)>> {
-            constexpr auto operator()(fixed_point<Rep, Exponent, Radix> const& input) const
-            -> decltype(to_rep(input) << Exponent)
-            {
-                return to_rep(input) << Exponent;
-            }
-        };
-
-        template<typename Scalar>
-        constexpr auto trunc(Scalar const& scalar)
-        -> decltype(trunc_fn<Scalar>{}(scalar))
+        constexpr auto trunc(fixed_point<Rep, Radix, Exponent> const& scalar)
+        -> decltype(scale<Radix, Exponent>(to_rep(scalar)))
         {
-            return trunc_fn<Scalar>{}(scalar);
+            return scale<Radix, Exponent>(to_rep(scalar));
         }
 
         template<typename Scalar>
@@ -121,10 +100,10 @@ namespace cnl {
             do {
                 value *= 10;
                 auto const unit = trunc(value);
-                *first = itoc(value);
+                *first = itoc(unit);
                 ++first;
 
-                value ^= unit;
+                value -= unit;
                 if (!value) {
                     break;
                 }
@@ -146,7 +125,7 @@ namespace cnl {
                 return to_chars_result{last, std::errc::value_too_large};
             }
 
-            auto const fractional = value ^natural;
+            auto const fractional = value - natural;
             if (!fractional) {
                 return to_chars_result{natural_last, std::errc{}};
             }

--- a/src/test/fixed_point/to_chars.h
+++ b/src/test/fixed_point/to_chars.h
@@ -242,6 +242,31 @@ namespace {
         {
             test<4>("-7.0", cnl::fixed_point<int, -28>(-7.00390625));
         }
+
+        TEST(to_chars, fixed_point_decimal_positive)
+        {
+            test<6>("17.917", cnl::fixed_point<int, -3, 10>(17.917));
+        }
+
+        TEST(to_chars, fixed_point_decimal_negative)
+        {
+            test<5>("-5.25", cnl::fixed_point<int, -2, 10>(-5.25));
+        }
+
+        TEST(to_chars, fixed_point_decimal_no_fractional)
+        {
+            test<7>("-517523", cnl::fixed_point<int, 0, 10>(-517523));
+        }
+
+        TEST(to_chars, fixed_point_octal_positive)
+        {
+            test<9>("634124.25", cnl::fixed_point<int, -1, 8>(634124.25));
+        }
+
+        TEST(to_chars, fixed_point_octal_negative)
+        {
+            test<7>("-33.125", cnl::fixed_point<int, -1, 8>(-33.125));
+        }
     }
 }
 


### PR DESCRIPTION
The `trunc_fn` and some of the arithmetic in fixed_point/to_chars.h assumed the radix was always 2 and was producing incorrect results when used with other radii.  Using scale() seems to handle this better and produces correct results for different radii, though there could be a better approach.