### PR TITLE
Add support for AppleClang on macOS

### DIFF
--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -3,11 +3,22 @@
 ######################################################################
 # build flags
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "AppleClang" IS_APPLECLANG)
+string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "Clang" IS_CLANG)
+string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "GNU" IS_GCC_FAMILY)
+string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "MSVC" IS_MSVC)
+
+if (IS_CLANG OR IS_APPLECLANG)
+    set(IS_CLANG_FAMILY 1)
+else ()
+    set(IS_CLANG_FAMILY 0)
+endif ()
+
+if (IS_MSVC)
   # https://developercommunity.visualstudio.com/content/problem/55671/c4307-issued-for-unsigned.html
   set(MISC_FLAGS "/W4 /WX /errorReport:prompt /nologo /wd4307")
 
-  # no tested
+  # not tested
   set(CPP17_ENABLED_FLAGS "/std:c++17")
 
   set(EXCEPTION_ENABLED_FLAGS "/GR /EHsc")
@@ -19,12 +30,16 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 
   set(PROFILE_ENABLED_FLAGS "/Oy-")
   set(PROFILE_DISABLED_FLAGS "")
-elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-  set(MISC_FLAGS "-pthread -Wall -Wextra -Werror -ftemplate-backtrace-limit=0")
+elseif (IS_CLANG_FAMILY OR IS_GCC_FAMILY)
+  set(MISC_FLAGS "-Wall -Wextra -Werror -ftemplate-backtrace-limit=0")
 
-  if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
-    set(MISC_FLAGS "${MISC_FLAGS} -fconstexpr-backtrace-limit=0 -fconstexpr-steps=100000000")
-  endif()
+  if (NOT IS_APPLECLANG)
+      string(APPEND MISC_FLAGS " -pthread")
+  endif ()
+
+  if (IS_CLANG)
+      string(APPEND MISC_FLAGS " -fconstexpr-backtrace-limit=0 -fconstexpr-steps=100000000")
+  endif ()
 
   set(CPP17_ENABLED_FLAGS "-std=c++17")
 

--- a/src/single_header/CMakeLists.txt
+++ b/src/single_header/CMakeLists.txt
@@ -25,7 +25,7 @@ function(make_single_header target output header version int128_flag gcc_intrins
     endif (TARGET Doc)
 endfunction()
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+if (IS_CLANG_FAMILY)
     make_single_header(SingleHeader11     cnl_complete_11.h        header11.h "c++11" "0" "-DCNL_USE_GCC_INTRINSICS=0")
     make_single_header(SingleHeader11_128 cnl_complete_11_128bit.h header11.h "c++11" "1" "-DCNL_USE_GCC_INTRINSICS=1")
     make_single_header(SingleHeader14     cnl_complete_14.h        header14.h "c++14" "0" "-DCNL_USE_GCC_INTRINSICS=0")

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -127,7 +127,7 @@ if(Boost_FOUND)
     endif(NOT Boost_VERSION GREATER 105500)
 endif(Boost_FOUND)
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+if (IS_MSVC)
     set(gtest_byproducts
             "${CMAKE_CURRENT_BINARY_DIR}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtestd${CMAKE_FIND_LIBRARY_SUFFIXES}"
             "${CMAKE_CURRENT_BINARY_DIR}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_maind${CMAKE_FIND_LIBRARY_SUFFIXES}"
@@ -223,9 +223,9 @@ endfunction(make_test)
 ######################################################################
 # create tests to verify CNL
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+if (IS_MSVC)
     set(SANITIZE_ENABLED_CXX_FLAGS "")
-elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+elseif (IS_CLANG)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.8.0")
         set(SANITIZE_ENABLED_CXX_FLAGS "-fsanitize=undefined -fsanitize=address")
         set(SANITIZE_ENABLED_LINKER_FLAGS "-fsanitize=undefined --rtlib=compiler-rt -lasan")
@@ -238,7 +238,7 @@ else ()
     set(SANITIZE_ENABLED_LINKER_FLAGS "-fsanitize=address -static-libasan")
 endif ()
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+if (IS_MSVC)
     set(TEST_CXX_FLAGS "")
 else ()
     set(TEST_CXX_FLAGS "-Wconversion -Wno-sign-conversion -ftemplate-backtrace-limit=0")
@@ -258,7 +258,7 @@ endforeach(source)
 # create tests to show off CNL
 
 foreach(source ${sample_sources})
-    if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+    if (IS_CLANG_FAMILY OR IS_GCC_FAMILY)
         make_test("${source}" target "-fpermissive -Wno-sign-compare -Wno-strict-overflow" "")
     else ()
         make_test("${source}" target "/wd4018" "")
@@ -277,8 +277,8 @@ add_dependencies(Test-glm Glm)
 
 if(Boost_FOUND AND Boost_VERSION GREATER 106099 AND EXCEPTIONS)
     # Boost.SIMD has problems building with gcc-7.x
-    if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.0.0")
-        if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+    if(IS_GCC_FAMILY OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.0.0")
+        if (IS_CLANG_FAMILY OR IS_GCC_FAMILY)
             make_test(boost.simd.cpp target "-Wno-conversion" "")
         else ()
             make_test(boost.simd.cpp target "" "")
@@ -296,13 +296,13 @@ if(Boost_FOUND AND Boost_VERSION GREATER 106099 AND EXCEPTIONS)
 
         ExternalProject_Get_Property(BoostSimd source_dir)
         target_include_directories("${target}" PRIVATE SYSTEM "${source_dir}/include")
-    endif(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.0.0")
+    endif(IS_GCC_FAMILY OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.0.0")
 endif(Boost_FOUND AND Boost_VERSION GREATER 106099 AND EXCEPTIONS)
 
 ######################################################################
 # create test of Vc integration
 
-if(${STD} STREQUAL "17" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "7.0.0"
+if(${STD} STREQUAL "17" AND IS_GCC_FAMILY AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "7.0.0"
         AND CMAKE_VERSION VERSION_GREATER "3.2")
     make_test(vc.cpp target "" "")
 


### PR DESCRIPTION
This PR introduces some _compiler test_ variables in common.cmake. It also checks for the AppleClang compiler, which was previously never checked for (causing CMake to bail on macOS).