### PR TITLE
Free functions

### DIFF
--- a/include/cnl/_impl/native_tag.h
+++ b/include/cnl/_impl/native_tag.h
@@ -69,16 +69,6 @@ namespace cnl {
                 return static_cast<result_type>(static_cast<cnl::make_unsigned_t<result_type>>(lhs)<<rhs);
             }
         };
-
-        ////////////////////////////////////////////////////////////////////////////////
-        // cnl::convert
-
-        template<class Tag, typename Result, typename Input>
-        constexpr auto convert(Input const& from)
-        -> decltype(cnl::_impl::tagged_convert_operator<Tag, Result, Input>{}(from))
-        {
-            return cnl::_impl::tagged_convert_operator<Tag, Result, Input>{}(from);
-        }
     }
 }
 

--- a/include/cnl/_impl/overflow/native.h
+++ b/include/cnl/_impl/overflow/native.h
@@ -14,16 +14,13 @@
 
 /// compositional numeric library
 namespace cnl {
-    // match the behavior of fundamental arithmetic types
-    struct native_overflow_tag : _impl::native_tag {
-    };
-
-    static constexpr native_overflow_tag native_overflow{};
-
-    ////////////////////////////////////////////////////////////////////////////////
-    // arithmetic overflow
-
     namespace _impl {
+        // match the behavior of fundamental arithmetic types
+        struct native_overflow_tag : _impl::native_tag {
+        };
+
+        static constexpr _impl::native_overflow_tag native_overflow{};
+
         template<typename Operator, polarity Polarity>
         struct overflow_operator<Operator, native_overflow_tag, Polarity> : Operator {
         };

--- a/include/cnl/_impl/overflow/saturated.h
+++ b/include/cnl/_impl/overflow/saturated.h
@@ -14,8 +14,8 @@
 /// compositional numeric library
 namespace cnl {
     // confine range of results
-    static constexpr struct saturated_overflow_tag {
-    } saturated_overflow{};
+    struct saturated_overflow_tag {
+    };
 
     namespace _impl {
         template<typename Operator>

--- a/include/cnl/_impl/overflow/throwing.h
+++ b/include/cnl/_impl/overflow/throwing.h
@@ -17,8 +17,8 @@
 namespace cnl {
     // terminate program with diagnostic when overflow is detected
     // throw an exception when overflow is don overflowetected
-    static constexpr struct throwing_overflow_tag {
-    } throwing_overflow{};
+    struct throwing_overflow_tag {
+    };
 
     namespace _impl {
         template<typename Operator>

--- a/include/cnl/_impl/overflow/trapping.h
+++ b/include/cnl/_impl/overflow/trapping.h
@@ -14,8 +14,8 @@
 /// compositional numeric library
 namespace cnl {
     // terminate program with diagnostic when overflow is detected
-    static constexpr struct trapping_overflow_tag {
-    } trapping_overflow{};
+    struct trapping_overflow_tag {
+    };
 
     namespace _impl {
         template<typename Operator>

--- a/include/cnl/_impl/overflow/undefined.h
+++ b/include/cnl/_impl/overflow/undefined.h
@@ -14,8 +14,8 @@
 /// compositional numeric library
 namespace cnl {
     // terminate program with diagnostic when overflow is detected
-    static constexpr struct undefined_overflow_tag {
-    } undefined_overflow{};
+    struct undefined_overflow_tag {
+    };
 
     namespace _impl {
         template<typename Operator>

--- a/include/cnl/_impl/tagged.h
+++ b/include/cnl/_impl/tagged.h
@@ -20,21 +20,21 @@ namespace cnl {
     }
 
     template<class Tag, typename Lhs, typename Rhs>
-    constexpr auto add(Tag, Lhs const& lhs, Rhs const& rhs)
+    constexpr auto add(Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs+rhs)
     {
         return _impl::tagged_binary_operator<Tag, _impl::add_op>{}(lhs, rhs);
     }
 
     template<class Tag, typename Lhs, typename Rhs>
-    constexpr auto subtract(Tag, Lhs const& lhs, Rhs const& rhs)
+    constexpr auto subtract(Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs-rhs)
     {
         return _impl::tagged_binary_operator<Tag, _impl::subtract_op>{}(lhs, rhs);
     }
 
     template<class Tag, typename Lhs, typename Rhs>
-    constexpr auto multiply(Tag, Lhs const& lhs, Rhs const& rhs)
+    constexpr auto multiply(Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs*rhs)
     {
         return _impl::tagged_binary_operator<Tag, _impl::multiply_op>{}(lhs, rhs);
@@ -48,7 +48,7 @@ namespace cnl {
     }
 
     template<class Tag, typename Lhs, typename Rhs>
-    constexpr auto shift_left(Tag, Lhs const& lhs, Rhs const& rhs)
+    constexpr auto shift_left(Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs<<rhs)
     {
         return _impl::tagged_binary_operator<Tag, _impl::shift_left_op>{}(

--- a/include/cnl/_impl/tagged.h
+++ b/include/cnl/_impl/tagged.h
@@ -21,21 +21,21 @@ namespace cnl {
 
     template<class Tag, typename Lhs, typename Rhs>
     constexpr auto add(Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs+rhs)
+    -> decltype(_impl::tagged_binary_operator<Tag, _impl::add_op>{}(lhs, rhs))
     {
         return _impl::tagged_binary_operator<Tag, _impl::add_op>{}(lhs, rhs);
     }
 
     template<class Tag, typename Lhs, typename Rhs>
     constexpr auto subtract(Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs-rhs)
+    -> decltype(_impl::tagged_binary_operator<Tag, _impl::subtract_op>{}(lhs, rhs))
     {
         return _impl::tagged_binary_operator<Tag, _impl::subtract_op>{}(lhs, rhs);
     }
 
     template<class Tag, typename Lhs, typename Rhs>
     constexpr auto multiply(Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs*rhs)
+    -> decltype(_impl::tagged_binary_operator<Tag, _impl::multiply_op>{}(lhs, rhs))
     {
         return _impl::tagged_binary_operator<Tag, _impl::multiply_op>{}(lhs, rhs);
     }
@@ -49,10 +49,9 @@ namespace cnl {
 
     template<class Tag, typename Lhs, typename Rhs>
     constexpr auto shift_left(Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs<<rhs)
+    -> decltype(_impl::tagged_binary_operator<Tag, _impl::shift_left_op>{}(lhs, rhs))
     {
-        return _impl::tagged_binary_operator<Tag, _impl::shift_left_op>{}(
-                unwrap(lhs), unwrap(rhs));
+        return _impl::tagged_binary_operator<Tag, _impl::shift_left_op>{}(lhs, rhs);
     }
 
     template<class Tag, typename Lhs, typename Rhs>

--- a/include/cnl/_impl/tagged.h
+++ b/include/cnl/_impl/tagged.h
@@ -18,6 +18,20 @@ namespace cnl {
     {
         return cnl::_impl::tagged_convert_operator<Tag, Result, Input>{}(from);
     }
+
+    template<class Tag, typename Dividend, typename Divisor>
+    constexpr auto divide(Dividend const& dividend, Divisor const& divisor)
+    -> decltype(cnl::_impl::tagged_binary_operator<Tag, _impl::divide_op>{}.template operator()<Dividend, Divisor>(dividend, divisor))
+    {
+        return cnl::_impl::tagged_binary_operator<Tag, _impl::divide_op>{}.template operator()<Dividend, Divisor>(dividend, divisor);
+    }
+
+    template<class Tag, typename Lhs, typename Rhs>
+    constexpr auto shift_right(Lhs const& lhs, Rhs const& rhs)
+    -> decltype(cnl::_impl::tagged_binary_operator<Tag, _impl::shift_right_op>{}.template operator()<Lhs, Rhs>(lhs, rhs))
+    {
+        return cnl::_impl::tagged_binary_operator<Tag, _impl::shift_right_op>{}.template operator()<Lhs, Rhs>(lhs, rhs);
+    }
 }
 
 #endif  // CNL_IMPL_TAGGED_H

--- a/include/cnl/_impl/tagged.h
+++ b/include/cnl/_impl/tagged.h
@@ -1,0 +1,23 @@
+
+//          Copyright John McFarlane 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file
+/// \brief free functions performing customizable operations on arithmetic types
+
+#ifndef CNL_IMPL_TAGGED_H
+#define CNL_IMPL_TAGGED_H
+
+/// compositional numeric library
+namespace cnl {
+    template<class Tag, typename Result, typename Input>
+    constexpr auto convert(Input const& from)
+    -> decltype(cnl::_impl::tagged_convert_operator<Tag, Result, Input>{}(from))
+    {
+        return cnl::_impl::tagged_convert_operator<Tag, Result, Input>{}(from);
+    }
+}
+
+#endif  // CNL_IMPL_TAGGED_H

--- a/include/cnl/_impl/tagged.h
+++ b/include/cnl/_impl/tagged.h
@@ -19,11 +19,40 @@ namespace cnl {
         return cnl::_impl::tagged_convert_operator<Tag, Result, Input>{}(from);
     }
 
+    template<class OverflowTag, class Lhs, class Rhs>
+    constexpr auto add(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    -> decltype(lhs+rhs)
+    {
+        return _impl::tagged_binary_operator<OverflowTag, _impl::add_op>{}(lhs, rhs);
+    }
+
+    template<class OverflowTag, class Lhs, class Rhs>
+    constexpr auto subtract(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    -> decltype(lhs-rhs)
+    {
+        return _impl::tagged_binary_operator<OverflowTag, _impl::subtract_op>{}(lhs, rhs);
+    }
+
+    template<class OverflowTag, class Lhs, class Rhs>
+    constexpr auto multiply(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    -> decltype(lhs*rhs)
+    {
+        return _impl::tagged_binary_operator<OverflowTag, _impl::multiply_op>{}(lhs, rhs);
+    }
+
     template<class Tag, typename Dividend, typename Divisor>
     constexpr auto divide(Dividend const& dividend, Divisor const& divisor)
     -> decltype(cnl::_impl::tagged_binary_operator<Tag, _impl::divide_op>{}.template operator()<Dividend, Divisor>(dividend, divisor))
     {
         return cnl::_impl::tagged_binary_operator<Tag, _impl::divide_op>{}.template operator()<Dividend, Divisor>(dividend, divisor);
+    }
+
+    template<class OverflowTag, class Lhs, class Rhs>
+    constexpr auto shift_left(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    -> decltype(lhs<<rhs)
+    {
+        return _impl::tagged_binary_operator<OverflowTag, _impl::shift_left_op>{}(
+                unwrap(lhs), unwrap(rhs));
     }
 
     template<class Tag, typename Lhs, typename Rhs>

--- a/include/cnl/_impl/tagged.h
+++ b/include/cnl/_impl/tagged.h
@@ -19,25 +19,25 @@ namespace cnl {
         return cnl::_impl::tagged_convert_operator<Tag, Result, Input>{}(from);
     }
 
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto add(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    template<class Tag, typename Lhs, typename Rhs>
+    constexpr auto add(Tag, Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs+rhs)
     {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::add_op>{}(lhs, rhs);
+        return _impl::tagged_binary_operator<Tag, _impl::add_op>{}(lhs, rhs);
     }
 
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto subtract(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    template<class Tag, typename Lhs, typename Rhs>
+    constexpr auto subtract(Tag, Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs-rhs)
     {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::subtract_op>{}(lhs, rhs);
+        return _impl::tagged_binary_operator<Tag, _impl::subtract_op>{}(lhs, rhs);
     }
 
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto multiply(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    template<class Tag, typename Lhs, typename Rhs>
+    constexpr auto multiply(Tag, Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs*rhs)
     {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::multiply_op>{}(lhs, rhs);
+        return _impl::tagged_binary_operator<Tag, _impl::multiply_op>{}(lhs, rhs);
     }
 
     template<class Tag, typename Dividend, typename Divisor>
@@ -47,11 +47,11 @@ namespace cnl {
         return cnl::_impl::tagged_binary_operator<Tag, _impl::divide_op>{}.template operator()<Dividend, Divisor>(dividend, divisor);
     }
 
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto shift_left(OverflowTag, Lhs const& lhs, Rhs const& rhs)
+    template<class Tag, typename Lhs, typename Rhs>
+    constexpr auto shift_left(Tag, Lhs const& lhs, Rhs const& rhs)
     -> decltype(lhs<<rhs)
     {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::shift_left_op>{}(
+        return _impl::tagged_binary_operator<Tag, _impl::shift_left_op>{}(
                 unwrap(lhs), unwrap(rhs));
     }
 

--- a/include/cnl/overflow.h
+++ b/include/cnl/overflow.h
@@ -22,38 +22,6 @@
 namespace cnl {
     using _impl::native_overflow_tag;
     using _impl::native_overflow;
-
-    ////////////////////////////////////////////////////////////////////////////////
-    // free overflow functions
-
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto add(OverflowTag, Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs+rhs)
-    {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::add_op>{}(lhs, rhs);
-    }
-
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto subtract(OverflowTag, Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs-rhs)
-    {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::subtract_op>{}(lhs, rhs);
-    }
-
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto multiply(OverflowTag, Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs*rhs)
-    {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::multiply_op>{}(lhs, rhs);
-    }
-
-    template<class OverflowTag, class Lhs, class Rhs>
-    constexpr auto shift_left(OverflowTag, Lhs const& lhs, Rhs const& rhs)
-    -> decltype(lhs<<rhs)
-    {
-        return _impl::tagged_binary_operator<OverflowTag, _impl::shift_left_op>{}(
-                unwrap(lhs), unwrap(rhs));
-    }
 }
 
 #endif  // CNL_OVERFLOW_H

--- a/include/cnl/overflow.h
+++ b/include/cnl/overflow.h
@@ -16,6 +16,7 @@
 #include "_impl/overflow/throwing.h"
 #include "_impl/overflow/trapping.h"
 #include "_impl/overflow/undefined.h"
+#include "_impl/tagged.h"
 
 /// compositional numeric library
 namespace cnl {

--- a/include/cnl/overflow.h
+++ b/include/cnl/overflow.h
@@ -20,6 +20,9 @@
 
 /// compositional numeric library
 namespace cnl {
+    using _impl::native_overflow_tag;
+    using _impl::native_overflow;
+
     ////////////////////////////////////////////////////////////////////////////////
     // free overflow functions
 

--- a/include/cnl/overflow.h
+++ b/include/cnl/overflow.h
@@ -21,7 +21,6 @@
 /// compositional numeric library
 namespace cnl {
     using _impl::native_overflow_tag;
-    using _impl::native_overflow;
 }
 
 #endif  // CNL_OVERFLOW_H

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -148,9 +148,9 @@ namespace cnl {
             _impl::enable_if_t<(Digits>=0)>> {
         using _value_type = overflow_integer<Rep, OverflowTag>;
         constexpr auto operator()(_value_type const& s) const
-        -> decltype(_impl::from_rep<_value_type>(shift_left(OverflowTag{}, _impl::to_rep(s), constant<Digits>{})))
+        -> decltype(_impl::from_rep<_value_type>(shift_left<OverflowTag>(_impl::to_rep(s), constant<Digits>{})))
         {
-            return _impl::from_rep<_value_type>(shift_left(OverflowTag{}, _impl::to_rep(s), constant<Digits>{}));
+            return _impl::from_rep<_value_type>(shift_left<OverflowTag>( _impl::to_rep(s), constant<Digits>{}));
         }
     };
 

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -16,6 +16,7 @@
 #include "_impl/number_base.h"
 #include "_impl/generic_operators.h"
 #include "_impl/ostream.h"
+#include "_impl/tagged.h"
 #include "_impl/type_traits/common_type.h"
 #include "_impl/type_traits/identical.h"
 
@@ -75,7 +76,7 @@ namespace cnl {
 
         template<class Rhs, _impl::enable_if_t<!_integer_impl::is_overflow_integer<Rhs>::value, int> dummy = 0>
         constexpr overflow_integer(Rhs const& rhs)
-                :_base(_impl::convert<overflow_tag, rep>(rhs))
+                :_base(convert<overflow_tag, rep>(rhs))
         {
         }
 
@@ -91,7 +92,7 @@ namespace cnl {
         template<class T>
         constexpr explicit operator T() const
         {
-            return _impl::convert<overflow_tag, T>(_impl::to_rep(*this));
+            return convert<overflow_tag, T>(_impl::to_rep(*this));
         }
     };
 

--- a/include/cnl/overflow_integer.h
+++ b/include/cnl/overflow_integer.h
@@ -108,6 +108,16 @@ namespace cnl {
         using type = overflow_integer<set_digits_t<Rep, MinNumBits>, OverflowTag>;
     };
 
+    template<int Digits, int Radix, typename Rep, class OverflowTag>
+    struct scale<Digits, Radix, overflow_integer<Rep, OverflowTag>> {
+        using _value_type = overflow_integer<Rep, OverflowTag>;
+        constexpr auto operator()(_value_type const& s) const
+        -> decltype(_impl::from_rep<_value_type>(_impl::scale<Digits, Radix>(_impl::to_rep(s))))
+        {
+            return _impl::default_scale<Digits, Radix, _value_type>{}(s);
+        }
+    };
+
     /// \brief \ref overflow_integer specialization of \ref from_rep
     /// \tparam ArchetypeRep ignored; replaced by \c Rep
     /// \tparam OverflowTag the \c OverflowTag of the generated type
@@ -141,23 +151,6 @@ namespace cnl {
                     typename std::conditional<
                             digits<int>::value<_impl::used_digits(Value), decltype(Value), int>::type, OverflowTag>,
                     constant<Value>>{
-    };
-
-    template<int Digits, class Rep, class OverflowTag>
-    struct scale<Digits, 2, overflow_integer<Rep, OverflowTag>,
-            _impl::enable_if_t<(Digits>=0)>> {
-        using _value_type = overflow_integer<Rep, OverflowTag>;
-        constexpr auto operator()(_value_type const& s) const
-        -> decltype(_impl::from_rep<_value_type>(shift_left<OverflowTag>(_impl::to_rep(s), constant<Digits>{})))
-        {
-            return _impl::from_rep<_value_type>(shift_left<OverflowTag>( _impl::to_rep(s), constant<Digits>{}));
-        }
-    };
-
-    template<int Digits, int Radix, class Rep, class OverflowTag>
-    struct scale<Digits, Radix, overflow_integer<Rep, OverflowTag>,
-            _impl::enable_if_t<(Digits<0||Radix!=2)>>
-            : scale<Digits, Radix, _impl::number_base<overflow_integer<Rep, OverflowTag>, Rep>> {
     };
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/cnl/rounding.h
+++ b/include/cnl/rounding.h
@@ -11,6 +11,7 @@
 #define CNL_ROUNDING_H
 
 #include "_impl/rounding.h"
+#include "_impl/tagged.h"
 
 /// compositional numeric library
 namespace cnl {

--- a/include/cnl/rounding.h
+++ b/include/cnl/rounding.h
@@ -17,9 +17,6 @@
 namespace cnl {
     using _impl::nearest_rounding_tag;
     using _impl::native_rounding_tag;
-
-    using _impl::divide;
-    using _impl::shift_right;
 }
 
 #endif  // CNL_ROUNDING_H

--- a/include/cnl/rounding_integer.h
+++ b/include/cnl/rounding_integer.h
@@ -14,6 +14,7 @@
 #include "_impl/num_traits/to_rep.h"
 #include "_impl/number_base.h"
 #include "_impl/rounding.h"
+#include "_impl/tagged.h"
 #include "_impl/type_traits/common_type.h"
 #include "_impl/used_digits.h"
 
@@ -88,7 +89,7 @@ namespace cnl {
 
         template<class T>
         constexpr rounding_integer(T const& v)
-                : _base(_impl::convert<rounding, Rep>(v)) { }
+                : _base(convert<rounding, Rep>(v)) { }
 
         template<class T>
         constexpr explicit operator T() const

--- a/src/test/_impl/rounding/tagged_convert_operator.cpp
+++ b/src/test/_impl/rounding/tagged_convert_operator.cpp
@@ -21,62 +21,62 @@ namespace  test_convert_nearest_rounding_native_datatypes
 {
 
     static_assert(
-            cnl::_impl::identical(0.123f, cnl::_impl::convert<cnl::nearest_rounding_tag, float, float>(0.123f)),
-            "cnl::_impl::convert<nearest_rounding_tag, float, float>");
+            cnl::_impl::identical(0.123f, cnl::convert<cnl::nearest_rounding_tag, float, float>(0.123f)),
+            "cnl::convert<nearest_rounding_tag, float, float>");
 
     static_assert(
-            cnl::_impl::identical(0.125, cnl::_impl::convert<cnl::nearest_rounding_tag, double, float>(0.125f)),
-            "cnl::_impl::convert<nearest_rounding_tag, double, float>");
+            cnl::_impl::identical(0.125, cnl::convert<cnl::nearest_rounding_tag, double, float>(0.125f)),
+            "cnl::convert<nearest_rounding_tag, double, float>");
 
     static_assert(
-            cnl::_impl::identical(0, cnl::_impl::convert<cnl::nearest_rounding_tag, int, float>(0.125f)),
-            "cnl::_impl::convert<nearest_rounding_tag, int, float>");
+            cnl::_impl::identical(0, cnl::convert<cnl::nearest_rounding_tag, int, float>(0.125f)),
+            "cnl::convert<nearest_rounding_tag, int, float>");
 
     static_assert(
-            cnl::_impl::identical(1, cnl::_impl::convert<cnl::nearest_rounding_tag, int, float>(0.725f)),
-            "cnl::_impl::convert<nearest_rounding_tag, int, float>");
+            cnl::_impl::identical(1, cnl::convert<cnl::nearest_rounding_tag, int, float>(0.725f)),
+            "cnl::convert<nearest_rounding_tag, int, float>");
 
     static_assert(
-            cnl::_impl::identical(-1, cnl::_impl::convert<cnl::nearest_rounding_tag, int, float>(-0.725f)),
-            "cnl::_impl::convert<nearest_rounding_tag, int, float>");
+            cnl::_impl::identical(-1, cnl::convert<cnl::nearest_rounding_tag, int, float>(-0.725f)),
+            "cnl::convert<nearest_rounding_tag, int, float>");
 
     static_assert(
-            cnl::_impl::identical(3, cnl::_impl::convert<cnl::nearest_rounding_tag, int, int>(3)),
-            "cnl::_impl::convert<nearest_rounding_tag, int, int>");
+            cnl::_impl::identical(3, cnl::convert<cnl::nearest_rounding_tag, int, int>(3)),
+            "cnl::convert<nearest_rounding_tag, int, int>");
 
     static_assert(
-            cnl::_impl::identical(3L, cnl::_impl::convert<cnl::nearest_rounding_tag, long, int>(3)),
-            "cnl::_impl::convert<nearest_rounding_tag, long, int>");
+            cnl::_impl::identical(3L, cnl::convert<cnl::nearest_rounding_tag, long, int>(3)),
+            "cnl::convert<nearest_rounding_tag, long, int>");
 
     static_assert(
-            cnl::_impl::identical(3.0, cnl::_impl::convert<cnl::nearest_rounding_tag, double, int>(3)),
-            "cnl::_impl::convert<nearest_rounding_tag, double, int>");
+            cnl::_impl::identical(3.0, cnl::convert<cnl::nearest_rounding_tag, double, int>(3)),
+            "cnl::convert<nearest_rounding_tag, double, int>");
 }
 
 namespace test_convert_nearest_rounding_elastic_number
 {
     static constexpr auto a = cnl::elastic_number<8, -4>{0.3125};
     static constexpr auto b =
-            cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -1>, cnl::elastic_number<8, -4>>(a);
+            cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -1>, cnl::elastic_number<8, -4>>(a);
     static_assert(identical(cnl::elastic_number<4, -1>{0.5}, b),
-            "cnl::_impl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
+            "cnl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
 
     static constexpr auto c =
-            cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -2>, cnl::elastic_number<8, -4>>(a);
+            cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -2>, cnl::elastic_number<8, -4>>(a);
     static_assert(identical(cnl::elastic_number<4, -2>{0.25}, c),
-            "cnl::_impl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
+            "cnl::convert<nearest_rounding_tag, elastic_number, elastic_number>");
 }
 
 namespace test_convert_nearest_rounding_fixed_point
 {
     static constexpr auto a = cnl::fixed_point<int, -4>{0.3125};
     static constexpr auto b =
-            cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -1>, cnl::fixed_point<int, -4>>(a);
+            cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -1>, cnl::fixed_point<int, -4>>(a);
     static_assert(identical(cnl::fixed_point<int, -1>{0.5}, b),
-            "cnl::_impl::convert<nearest_rounding_tag, fixed_point, fixed_point>");
+            "cnl::convert<nearest_rounding_tag, fixed_point, fixed_point>");
 
     static constexpr auto c =
-            cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -2>, cnl::fixed_point<int, -4>>(a);
+            cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -2>, cnl::fixed_point<int, -4>>(a);
     static_assert(identical(cnl::fixed_point<int, -2>{0.25}, c),
-            "cnl::_impl::convert<nearest_rounding_tag, fixed_point, fixed_point>");
+            "cnl::convert<nearest_rounding_tag, fixed_point, fixed_point>");
 }

--- a/src/test/elastic/rounding/elastic_integer_rounding.cpp
+++ b/src/test/elastic/rounding/elastic_integer_rounding.cpp
@@ -15,7 +15,7 @@ namespace {
         static_assert(
                 identical(
                         cnl::elastic_integer<53>{14},
-                        cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<62>, cnl::constant<9>>{}(
+                        cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<62>, cnl::constant<9>>(
                                 7000,
                                 cnl::constant<9>{})),
                 "shift_right(elastic_integer)");
@@ -24,7 +24,7 @@ namespace {
         static_assert(
                 identical(
                         cnl::elastic_integer<117>{14},
-                        cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<126>, cnl::constant<9>>{}(
+                        cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<126>, cnl::constant<9>>(
                                 7000,
                                 cnl::constant<9>{})),
                 "shift_right(elastic_integer)");

--- a/src/test/fixed_point/overflow/fixed_point_throwing_integer.cpp
+++ b/src/test/fixed_point/overflow/fixed_point_throwing_integer.cpp
@@ -20,24 +20,26 @@ using test_int = cnl::overflow_integer<int, cnl::throwing_overflow_tag>;
 
 #include "../fixed_point_common.h"
 
+#include <gtest/gtest.h>
+
 ////////////////////////////////////////////////////////////////////////////////
 // throwing_integer-specific exceptions tests
 
 
 #if defined(CNL_EXCEPTIONS_ENABLED)
 
-TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), narrow)
+TEST(throwing_integer_overflow_exception, narrow)
 {
     ASSERT_THROW((uint8) 0x1234, std::overflow_error);
 }
 
-TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), shift_left)
+TEST(throwing_integer_overflow_exception, shift_left)
 {
     auto scale = cnl::scale<30, 2, test_int>{};
     ASSERT_THROW(scale(2), std::overflow_error);
 }
 
-TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), assignment)
+TEST(throwing_integer_overflow_exception, assignment)
 {
     using fp_type = fixed_point<int8, -7>;
     ASSERT_THROW(fp_type(1), std::overflow_error);

--- a/src/test/fixed_point/overflow/fixed_point_throwing_integer.cpp
+++ b/src/test/fixed_point/overflow/fixed_point_throwing_integer.cpp
@@ -33,8 +33,8 @@ TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), narrow)
 
 TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), shift_left)
 {
-    constexpr auto scale = cnl::scale<31, 2, test_int>{};
-    ASSERT_THROW(scale(1), std::overflow_error);
+    auto scale = cnl::scale<30, 2, test_int>{};
+    ASSERT_THROW(scale(2), std::overflow_error);
 }
 
 TEST(TOKENPASTE2(TEST_LABEL, overflow_exception), assignment)

--- a/src/test/overflow/elastic/safe_integer.cpp
+++ b/src/test/overflow/elastic/safe_integer.cpp
@@ -60,7 +60,7 @@ namespace {
 
     namespace test_comparison {
         static_assert(identical(
-                cnl::_impl::convert<cnl::throwing_overflow_tag, cnl::elastic_integer<10>>(0),
+                cnl::convert<cnl::throwing_overflow_tag, cnl::elastic_integer<10>>(0),
                 cnl::elastic_integer<10>{0}), "");
 #if defined(__cpp_binary_literals)
         static_assert(cnl::safe_integer<10>(0b1010101010)==cnl::safe_integer<10>(0b1010101010), "");

--- a/src/test/overflow/overflow.cpp
+++ b/src/test/overflow/overflow.cpp
@@ -16,11 +16,11 @@ namespace {
         using cnl::native_overflow;
 
         // convert
-        static_assert(identical(cnl::_impl::convert<cnl::native_overflow_tag, cnl::uint8>(259), cnl::uint8{3}),
+        static_assert(identical(cnl::convert<cnl::native_overflow_tag, cnl::uint8>(259), cnl::uint8{3}),
                 "cnl::convert test failed");
-        static_assert(identical(cnl::_impl::convert<cnl::native_overflow_tag, cnl::uint16>(-123), cnl::uint16{65413}),
+        static_assert(identical(cnl::convert<cnl::native_overflow_tag, cnl::uint16>(-123), cnl::uint16{65413}),
                 "cnl::convert test failed");
-        static_assert(identical(cnl::_impl::convert<cnl::native_overflow_tag, cnl::int32>(55), 55),
+        static_assert(identical(cnl::convert<cnl::native_overflow_tag, cnl::int32>(55), 55),
                 "cnl::convert test failed");
 
         // add
@@ -52,11 +52,11 @@ namespace {
         using cnl::saturated_overflow;
 
         // convert
-        static_assert(identical(cnl::_impl::convert<cnl::saturated_overflow_tag, cnl::uint8>(259), cnl::uint8{255}),
+        static_assert(identical(cnl::convert<cnl::saturated_overflow_tag, cnl::uint8>(259), cnl::uint8{255}),
                 "cnl::convert test failed");
-        static_assert(identical(cnl::_impl::convert<cnl::saturated_overflow_tag, cnl::uint16>(-123), cnl::uint16{0}),
+        static_assert(identical(cnl::convert<cnl::saturated_overflow_tag, cnl::uint16>(-123), cnl::uint16{0}),
                 "cnl::convert test failed");
-        static_assert(identical(cnl::_impl::convert<cnl::saturated_overflow_tag, cnl::int32>(55), 55),
+        static_assert(identical(cnl::convert<cnl::saturated_overflow_tag, cnl::int32>(55), 55),
                 "cnl::convert test failed");
 
         // add
@@ -90,10 +90,10 @@ namespace {
 
         // compare
         static_assert(identical(
-                cnl::_impl::convert<cnl::saturated_overflow_tag, short>(cnl::numeric_limits<double>::max()),
+                cnl::convert<cnl::saturated_overflow_tag, short>(cnl::numeric_limits<double>::max()),
                 cnl::numeric_limits<short>::max()), "cnl::convert test failed");
         static_assert(identical(
-                cnl::_impl::convert<cnl::saturated_overflow_tag, short>(cnl::numeric_limits<double>::lowest()),
+                cnl::convert<cnl::saturated_overflow_tag, short>(cnl::numeric_limits<double>::lowest()),
                 cnl::numeric_limits<short>::lowest()), "cnl::convert test failed");
 
         // shift_left

--- a/src/test/overflow/overflow.cpp
+++ b/src/test/overflow/overflow.cpp
@@ -13,7 +13,6 @@ namespace {
     using cnl::_impl::identical;
 
     namespace test_native_overflow {
-        using cnl::native_overflow;
 
         // convert
         static_assert(identical(cnl::convert<cnl::native_overflow_tag, cnl::uint8>(259), cnl::uint8{3}),
@@ -24,16 +23,16 @@ namespace {
                 "cnl::convert test failed");
 
         // add
-        static_assert(identical(add(native_overflow, UINT32_C(0xFFFFFFFF), UINT32_C(0x12345678)), UINT32_C(0xFFFFFFFF)+UINT32_C(0x12345678)), "cnl::add test failed");
+        static_assert(identical(cnl::add(cnl::native_overflow, UINT32_C(0xFFFFFFFF), UINT32_C(0x12345678)), UINT32_C(0xFFFFFFFF)+UINT32_C(0x12345678)), "cnl::add test failed");
 
         // subtract
         static_assert(identical(
                 cnl::_impl::tagged_binary_operator<cnl::native_overflow_tag, cnl::_impl::subtract_op>()(INT8_C(0), INT8_C(0)),
                 0), "cnl::subtract test failed");
-        static_assert(identical(subtract(native_overflow, INT8_C(0), INT8_C(0)), 0), "cnl::subtract test failed");
+        static_assert(identical(cnl::subtract(cnl::native_overflow, INT8_C(0), INT8_C(0)), 0), "cnl::subtract test failed");
 
         // multiply
-        static_assert(identical(multiply(native_overflow, UINT16_C(576), INT32_C(22)), decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::multiply test failed");
+        static_assert(identical(cnl::multiply(cnl::native_overflow, UINT16_C(576), INT32_C(22)), decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::multiply test failed");
     }
 
     namespace test_throwing_overflow {

--- a/src/test/overflow/overflow.cpp
+++ b/src/test/overflow/overflow.cpp
@@ -23,33 +23,29 @@ namespace {
                 "cnl::convert test failed");
 
         // add
-        static_assert(identical(cnl::add(cnl::native_overflow, UINT32_C(0xFFFFFFFF), UINT32_C(0x12345678)), UINT32_C(0xFFFFFFFF)+UINT32_C(0x12345678)), "cnl::add test failed");
+        static_assert(identical(cnl::add<cnl::native_overflow_tag>(UINT32_C(0xFFFFFFFF), UINT32_C(0x12345678)), UINT32_C(0xFFFFFFFF)+UINT32_C(0x12345678)), "cnl::add test failed");
 
         // subtract
         static_assert(identical(
                 cnl::_impl::tagged_binary_operator<cnl::native_overflow_tag, cnl::_impl::subtract_op>()(INT8_C(0), INT8_C(0)),
                 0), "cnl::subtract test failed");
-        static_assert(identical(cnl::subtract(cnl::native_overflow, INT8_C(0), INT8_C(0)), 0), "cnl::subtract test failed");
+        static_assert(identical(cnl::subtract<cnl::native_overflow_tag>(INT8_C(0), INT8_C(0)), 0), "cnl::subtract test failed");
 
         // multiply
-        static_assert(identical(cnl::multiply(cnl::native_overflow, UINT16_C(576), INT32_C(22)), decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::multiply test failed");
+        static_assert(identical(cnl::multiply<cnl::native_overflow_tag>(UINT16_C(576), INT32_C(22)), decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::multiply test failed");
     }
 
     namespace test_throwing_overflow {
-        using cnl::throwing_overflow;
-
         // subtract
-        static_assert(identical(subtract(throwing_overflow, INT8_C(0), INT8_C(0)), 0), "cnl::add test failed");
+        static_assert(identical(cnl::subtract<cnl::throwing_overflow_tag>(INT8_C(0), INT8_C(0)), 0), "cnl::add test failed");
 
         // multiply
 #if ! defined(__APPLE__) || ! defined(__clang__)
-        static_assert(identical(multiply(throwing_overflow, UINT16_C(576), INT32_C(22)), decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::add test failed");
+        static_assert(identical(cnl::multiply<cnl::throwing_overflow_tag>(UINT16_C(576), INT32_C(22)), decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::add test failed");
 #endif
     }
 
     namespace test_saturated {
-        using cnl::saturated_overflow;
-
         // convert
         static_assert(identical(cnl::convert<cnl::saturated_overflow_tag, cnl::uint8>(259), cnl::uint8{255}),
                 "cnl::convert test failed");
@@ -64,27 +60,27 @@ namespace {
                 7+23U), "");
         static_assert(identical(
                 std::numeric_limits<decltype(UINT32_C(0xFFFFFFFF)+INT32_C(0x12345678))>::max(),
-                add(cnl::saturated_overflow, UINT32_C(0xFFFFFFFF), INT32_C(0x12345678))), "cnl::add test failed");
-        static_assert(identical(cnl::numeric_limits<decltype(2 + 2U)>::max(), add(saturated_overflow, 2, cnl::numeric_limits<unsigned>::max())), "cnl::add test failed");
+                cnl::add<cnl::saturated_overflow_tag>(UINT32_C(0xFFFFFFFF), INT32_C(0x12345678))), "cnl::add test failed");
+        static_assert(identical(cnl::numeric_limits<decltype(2 + 2U)>::max(), cnl::add<cnl::saturated_overflow_tag>(2, cnl::numeric_limits<unsigned>::max())), "cnl::add test failed");
 
         // subtract
-        static_assert(identical(subtract(saturated_overflow, INT8_C(0), INT8_C(0)), 0), "cnl::subtract test failed");
+        static_assert(identical(cnl::subtract<cnl::saturated_overflow_tag>(INT8_C(0), INT8_C(0)), 0), "cnl::subtract test failed");
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable: 4308)
 #endif
-        static_assert(identical(subtract(saturated_overflow, 0U, -1), 1U), "cnl::subtract test failed");
+        static_assert(identical(cnl::subtract<cnl::saturated_overflow_tag>(0U, -1), 1U), "cnl::subtract test failed");
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
         // multiply
 #if ! defined(__APPLE__) || ! defined(__clang__)
-        static_assert(identical(multiply(saturated_overflow, UINT16_C(576), INT32_C(22)),
+        static_assert(identical(cnl::multiply<cnl::saturated_overflow_tag>(UINT16_C(576), INT32_C(22)),
                 decltype(UINT16_C(576)*INT32_C(22)){12672}), "cnl::multiply test failed");
 #endif
         static_assert(identical(
-                multiply(saturated_overflow, cnl::numeric_limits<int32_t>::max(), INT32_C(2)),
+                cnl::multiply<cnl::saturated_overflow_tag>(cnl::numeric_limits<int32_t>::max(), INT32_C(2)),
                 cnl::numeric_limits<int32_t>::max()), "cnl::multiply test failed");
 
         // compare
@@ -98,15 +94,15 @@ namespace {
         // shift_left
         static_assert(identical(
                 cnl::numeric_limits<cnl::int16>::max()<<1,
-                cnl::shift_left(saturated_overflow, cnl::numeric_limits<cnl::int16>::max(), 1)),
+                cnl::shift_left<cnl::saturated_overflow_tag>(cnl::numeric_limits<cnl::int16>::max(), 1)),
                 "cnl::shift_left test failed");
         static_assert(identical(
                 cnl::numeric_limits<cnl::int32>::max(),
-                cnl::shift_left(saturated_overflow, cnl::numeric_limits<cnl::int32>::max(), 1)),
+                cnl::shift_left<cnl::saturated_overflow_tag>(cnl::numeric_limits<cnl::int32>::max(), 1)),
                 "cnl::shift_left test failed");
         static_assert(identical(
                 -2,
-                cnl::shift_left(saturated_overflow, -1, 1)),
+                cnl::shift_left<cnl::saturated_overflow_tag>(-1, 1)),
                 "cnl::shift_left test failed");
         static_assert(identical(
                 cnl::numeric_limits<int>::max(),
@@ -119,14 +115,14 @@ namespace {
         static_assert(
                 identical(
                         2*-1073741824,
-                        cnl::shift_left(cnl::trapping_overflow, -1073741824, 1)),
+                        cnl::shift_left<cnl::trapping_overflow_tag>(-1073741824, 1)),
                 "cnl::shift_left with negative input");
 
 #if !defined(CNL_UNREACHABLE_UB_ENABLED)
         TEST(overflow, trap)
         {
             ASSERT_DEATH(
-                    cnl::shift_left(cnl::trapping_overflow, -1073741825, 1),
+                    cnl::shift_left<cnl::trapping_overflow_tag>(-1073741825, 1),
                     "negative overflow");
         }
 #endif

--- a/src/test/rounding/fixed_point/elastic_integer/elastic_number.cpp
+++ b/src/test/rounding/fixed_point/elastic_integer/elastic_number.cpp
@@ -13,7 +13,7 @@ using cnl::_impl::identical;
 namespace {
     namespace test_nearest_round_down {
         static constexpr auto expected = cnl::elastic_number<4, -1>{0.5};
-        static constexpr auto actual = cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -1>>(
+        static constexpr auto actual = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -1>>(
                 cnl::elastic_number<8, -4>{0.3125});
 
         static_assert(
@@ -23,7 +23,7 @@ namespace {
 
     namespace test_nearest_round_up {
         static constexpr auto expected = cnl::elastic_number<4, -2>{0.25};
-        static constexpr auto actual = cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -2>>(
+        static constexpr auto actual = cnl::convert<cnl::nearest_rounding_tag, cnl::elastic_number<4, -2>>(
                 cnl::elastic_number<8, -4>{0.3125});
 
         static_assert(

--- a/src/test/rounding/fixed_point/fixed_point.cpp
+++ b/src/test/rounding/fixed_point/fixed_point.cpp
@@ -13,7 +13,7 @@ using cnl::_impl::identical;
 namespace {
     namespace test_nearest_round_down {
         static constexpr auto expected = cnl::fixed_point<int, -1>{0.5};
-        static constexpr auto actual = cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -1>>(
+        static constexpr auto actual = cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -1>>(
                 cnl::fixed_point<int, -4>{0.3125});
 
         static_assert(
@@ -23,7 +23,7 @@ namespace {
 
     namespace test_nearest_round_up {
         static constexpr auto expected = cnl::fixed_point<int, -2>{-0.25};
-        static constexpr auto actual = cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -2>>(
+        static constexpr auto actual = cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -2>>(
                 cnl::fixed_point<int, -4>{-0.3125});
 
         static_assert(
@@ -33,7 +33,7 @@ namespace {
 
     namespace test_nearest_round_up_float {
         static constexpr auto expected = cnl::fixed_point<int, -2>{-0.25};
-        static constexpr auto actual = cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -2>>(
+        static constexpr auto actual = cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, -2>>(
                 -0.3125f);
 
         static_assert(
@@ -43,7 +43,7 @@ namespace {
 
     namespace test_truncate_round_up {
         static constexpr auto expected = cnl::fixed_point<int, 0>{1};
-        static constexpr auto actual = cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, 0>>(
+        static constexpr auto actual = cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, 0>>(
                 cnl::fixed_point<int, -2>{0.75});
 
         static_assert(
@@ -55,13 +55,13 @@ namespace {
         static_assert(
                 identical(
                         3,
-                        cnl::_impl::convert<cnl::nearest_rounding_tag, int>(
+                        cnl::convert<cnl::nearest_rounding_tag, int>(
                                 cnl::fixed_point<int, -2>{2.5})),
                 "cnl::convert<cnl::nearest_rounding_tag, int, cnl::fixed_point>");
         static_assert(
                 identical(
                         2,
-                        cnl::_impl::convert<cnl::nearest_rounding_tag, int>(
+                        cnl::convert<cnl::nearest_rounding_tag, int>(
                                 cnl::fixed_point<int, -2>{2.4375})),
                 "cnl::convert<cnl::nearest_rounding_tag, int, cnl::fixed_point>");
     }
@@ -70,12 +70,12 @@ namespace {
         static_assert(
                 identical(
                         cnl::fixed_point<int, 2>{4},
-                        cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, 2>>(5)),
+                        cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, 2>>(5)),
                 "cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point, int>");
         static_assert(
                 identical(
                         cnl::fixed_point<int, 2>{8},
-                        cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, 2>>(6)),
+                        cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point<int, 2>>(6)),
                 "cnl::convert<cnl::nearest_rounding_tag, cnl::fixed_point, int>");
     }
 
@@ -89,7 +89,7 @@ namespace {
         static_assert(
                 identical(
                         2,
-                        cnl::_impl::convert<cnl::native_rounding_tag, int>(
+                        cnl::convert<cnl::native_rounding_tag, int>(
                                 cnl::fixed_point<int, -2>{2.4375})),
                 "cnl::convert<cnl::native_rounding_tag, int, cnl::fixed_point>");
     }
@@ -98,12 +98,12 @@ namespace {
         static_assert(
                 identical(
                         cnl::fixed_point<int, 2>{4},
-                        cnl::_impl::convert<cnl::native_rounding_tag, cnl::fixed_point<int, 2>>(5)),
+                        cnl::convert<cnl::native_rounding_tag, cnl::fixed_point<int, 2>>(5)),
                 "cnl::convert<cnl::native_rounding_tag, cnl::fixed_point, int>");
         static_assert(
                 identical(
                         cnl::fixed_point<int, 2>{4},
-                        cnl::_impl::convert<cnl::native_rounding_tag, cnl::fixed_point<int, 2>>(6)),
+                        cnl::convert<cnl::native_rounding_tag, cnl::fixed_point<int, 2>>(6)),
                 "cnl::convert<cnl::native_rounding_tag, cnl::fixed_point, int>");
     }
 }

--- a/src/test/rounding/rounding.cpp
+++ b/src/test/rounding/rounding.cpp
@@ -51,37 +51,37 @@ namespace {
         }
 
         namespace divide {
-            static_assert(identical(-1, cnl::divide<cnl::nearest_rounding_tag, int, int>{}(-990, 661)),
+            static_assert(identical(-1, cnl::divide<cnl::nearest_rounding_tag>(-990, 661)),
                     "cnl::divide test failed");
-            static_assert(identical(2, cnl::divide<cnl::nearest_rounding_tag, int, int>{}(-606, -404)),
+            static_assert(identical(2, cnl::divide<cnl::nearest_rounding_tag>(-606, -404)),
                     "cnl::divide test failed");
-            static_assert(identical(1, cnl::divide<cnl::nearest_rounding_tag, int, int>{}(8, 9)),
+            static_assert(identical(1, cnl::divide<cnl::nearest_rounding_tag>(8, 9)),
                     "cnl::divide test failed");
-            static_assert(identical(-1, cnl::divide<cnl::nearest_rounding_tag, int, int>{}(9, -8)),
+            static_assert(identical(-1, cnl::divide<cnl::nearest_rounding_tag>(9, -8)),
                     "cnl::divide test failed");
-            static_assert(identical(-2, cnl::divide<cnl::nearest_rounding_tag, int, int>{}(-9, 6)),
+            static_assert(identical(-2, cnl::divide<cnl::nearest_rounding_tag>(-9, 6)),
                     "cnl::divide test failed");
-            static_assert(identical(1, cnl::divide<cnl::nearest_rounding_tag, int, int>{}(-9, -7)),
+            static_assert(identical(1, cnl::divide<cnl::nearest_rounding_tag>(-9, -7)),
                     "cnl::divide test failed");
-            static_assert(identical(2, cnl::divide<cnl::nearest_rounding_tag, cnl::uint16, int>{}(999, 666)),
+            static_assert(identical(2, cnl::divide<cnl::nearest_rounding_tag, cnl::uint16, int>(999, 666)),
                     "cnl::divide test failed");
-            static_assert(identical(1LL, cnl::divide<cnl::nearest_rounding_tag, int, long long>{}(998, 666LL)),
+            static_assert(identical(1LL, cnl::divide<cnl::nearest_rounding_tag>(998, 666LL)),
                     "cnl::divide test failed");
         }
 
         namespace shift_right {
-            static_assert(identical(1, cnl::shift_right<cnl::nearest_rounding_tag, int, int>{}(1, 1)),
+            static_assert(identical(1, cnl::shift_right<cnl::nearest_rounding_tag>(1, 1)),
                     "cnl::shift_right test failed");
-            static_assert(identical(0, cnl::shift_right<cnl::nearest_rounding_tag, int, int>{}(1, 2)),
+            static_assert(identical(0, cnl::shift_right<cnl::nearest_rounding_tag>(1, 2)),
                     "cnl::shift_right test failed");
 
-            static_assert(identical(1, cnl::shift_right<cnl::nearest_rounding_tag, int, int>{}(191, 7)),
+            static_assert(identical(1, cnl::shift_right<cnl::nearest_rounding_tag>(191, 7)),
                     "cnl::shift_right test failed");
-            static_assert(identical(2, cnl::shift_right<cnl::nearest_rounding_tag, int, int>{}(192, 7)),
+            static_assert(identical(2, cnl::shift_right<cnl::nearest_rounding_tag>(192, 7)),
                     "cnl::shift_right test failed");
-            static_assert(identical(2, cnl::shift_right<cnl::nearest_rounding_tag, int, int>{}(319, 7)),
+            static_assert(identical(2, cnl::shift_right<cnl::nearest_rounding_tag>(319, 7)),
                     "cnl::shift_right test failed");
-            static_assert(identical(3, cnl::shift_right<cnl::nearest_rounding_tag, int, int>{}(320, 7)),
+            static_assert(identical(3, cnl::shift_right<cnl::nearest_rounding_tag>(320, 7)),
                     "cnl::shift_right test failed");
         }
     }

--- a/src/test/rounding/rounding.cpp
+++ b/src/test/rounding/rounding.cpp
@@ -14,39 +14,39 @@ namespace {
 
         namespace convert {
             static_assert(
-                    identical(cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::uint8>(200.5), cnl::uint8{201}),
+                    identical(cnl::convert<cnl::nearest_rounding_tag, cnl::uint8>(200.5), cnl::uint8{201}),
                     "cnl::convert test failed");
-            static_assert(identical(cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::int16>(-1000.5L),
+            static_assert(identical(cnl::convert<cnl::nearest_rounding_tag, cnl::int16>(-1000.5L),
                                     cnl::int16{-1001}),
                           "cnl::convert test failed");
-            static_assert(identical(cnl::_impl::convert<cnl::nearest_rounding_tag, cnl::int32>(55.2f), 55),
+            static_assert(identical(cnl::convert<cnl::nearest_rounding_tag, cnl::int32>(55.2f), 55),
                           "cnl::convert test failed");
 
-            static_assert(identical(-1, cnl::_impl::convert<cnl::nearest_rounding_tag, int>(-0.50)),
+            static_assert(identical(-1, cnl::convert<cnl::nearest_rounding_tag, int>(-0.50)),
                           "cnl::convert test failed");
-            static_assert(identical(-0, cnl::_impl::convert<cnl::nearest_rounding_tag, int>(-0.49)),
+            static_assert(identical(-0, cnl::convert<cnl::nearest_rounding_tag, int>(-0.49)),
                           "cnl::convert test failed");
-            static_assert(identical(+0, cnl::_impl::convert<cnl::nearest_rounding_tag, int>(0.49)),
+            static_assert(identical(+0, cnl::convert<cnl::nearest_rounding_tag, int>(0.49)),
                           "cnl::convert test failed");
-            static_assert(identical(+1, cnl::_impl::convert<cnl::nearest_rounding_tag, int>(0.50)),
+            static_assert(identical(+1, cnl::convert<cnl::nearest_rounding_tag, int>(0.50)),
                           "cnl::convert test failed");
 
             static_assert(
-                    identical(cnl::_impl::convert<cnl::native_rounding_tag, cnl::uint8>(200.5), cnl::uint8{200}),
+                    identical(cnl::convert<cnl::native_rounding_tag, cnl::uint8>(200.5), cnl::uint8{200}),
                     "cnl::convert test failed");
-            static_assert(identical(cnl::_impl::convert<cnl::native_rounding_tag, cnl::int16>(-1000.5L),
+            static_assert(identical(cnl::convert<cnl::native_rounding_tag, cnl::int16>(-1000.5L),
                                     cnl::int16{-1000}),
                           "cnl::convert test failed");
-            static_assert(identical(cnl::_impl::convert<cnl::native_rounding_tag, cnl::int32>(55.2f), 55),
+            static_assert(identical(cnl::convert<cnl::native_rounding_tag, cnl::int32>(55.2f), 55),
                           "cnl::convert test failed");
 
-            static_assert(identical(-0, cnl::_impl::convert<cnl::native_rounding_tag, int>(-0.50)),
+            static_assert(identical(-0, cnl::convert<cnl::native_rounding_tag, int>(-0.50)),
                           "cnl::convert test failed");
-            static_assert(identical(-0, cnl::_impl::convert<cnl::native_rounding_tag, int>(-0.49)),
+            static_assert(identical(-0, cnl::convert<cnl::native_rounding_tag, int>(-0.49)),
                           "cnl::convert test failed");
-            static_assert(identical(+0, cnl::_impl::convert<cnl::native_rounding_tag, int>(0.49)),
+            static_assert(identical(+0, cnl::convert<cnl::native_rounding_tag, int>(0.49)),
                           "cnl::convert test failed");
-            static_assert(identical(+0, cnl::_impl::convert<cnl::native_rounding_tag, int>(0.50)),
+            static_assert(identical(+0, cnl::convert<cnl::native_rounding_tag, int>(0.50)),
                           "cnl::convert test failed");
         }
 

--- a/src/test/zero_cost_free_functions.cpp
+++ b/src/test/zero_cost_free_functions.cpp
@@ -25,12 +25,12 @@ static_assert(identical(
         rounding_overflow_int<>{2} * rounding_overflow_int<>{3},
         rounding_overflow_int<>{6}), "");
 
-static_assert(identical(cnl::multiply(cnl::saturated_overflow, INT_MAX, INT_MAX), INT_MAX), "");
+static_assert(identical(cnl::multiply<cnl::saturated_overflow_tag>(INT_MAX, INT_MAX), INT_MAX), "");
 
 int bare_saturate(int a, int b) {
-    return multiply(saturated_overflow, a, b);
+    return cnl::multiply<cnl::saturated_overflow_tag>(a, b);
 }
 
 rounding_overflow_int<> psi_saturate(rounding_overflow_int<> a, rounding_overflow_int<> b) {
-    return multiply(saturated_overflow, a, b);
+    return cnl::multiply<cnl::saturated_overflow_tag>(a, b);
 }


### PR DESCRIPTION
Uniform free function API with `convert` restored to `cnl` namespace.