### PR TITLE
Right-shift rounding

### DIFF
--- a/include/cnl/_impl/native_tag.h
+++ b/include/cnl/_impl/native_tag.h
@@ -59,6 +59,7 @@ namespace cnl {
         template<class Operator>
         struct tagged_binary_operator<native_tag, Operator> : Operator {};
 
+#if (__cplusplus <= 201703L)
         template<>
         struct tagged_binary_operator<native_tag, shift_left_op> {
             template<class Lhs, class Rhs>
@@ -69,6 +70,7 @@ namespace cnl {
                 return static_cast<result_type>(static_cast<cnl::remove_signedness_t<result_type>>(lhs) << rhs);
             }
         };
+#endif
     }
 }
 

--- a/include/cnl/_impl/rounding.h
+++ b/include/cnl/_impl/rounding.h
@@ -49,19 +49,6 @@ namespace cnl {
         };
 
         ////////////////////////////////////////////////////////////////////////////////
-        // cnl::_impl::tagged_binary_operator<nearest_rounding_tag, shift_left_op>
-
-        template<>
-        struct tagged_binary_operator<nearest_rounding_tag, shift_left_op> {
-            template<class Lhs, class Rhs>
-            constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
-            -> decltype(lhs << rhs)
-            {
-                return lhs << rhs;
-            }
-        };
-
-        ////////////////////////////////////////////////////////////////////////////////
         // cnl::_impl::divide<nearest_rounding_tag, ...>
 
         template<class RoundingTag, class Lhs, class Rhs>

--- a/include/cnl/_impl/rounding.h
+++ b/include/cnl/_impl/rounding.h
@@ -49,20 +49,6 @@ namespace cnl {
         };
 
         ////////////////////////////////////////////////////////////////////////////////
-        // cnl::_impl::tagged_binary_operator<nearest_rounding_tag, shift_right_op>
-
-        template<>
-        struct tagged_binary_operator<nearest_rounding_tag, shift_right_op> {
-            template<class Lhs, class Rhs>
-            constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
-            -> decltype(lhs >> rhs)
-            {
-                return (lhs + ((static_cast<from_value_t<Lhs, constant<1>>>(constant<1>{}) << rhs) >> constant<1>{}))
-                        >> rhs;
-            }
-        };
-
-        ////////////////////////////////////////////////////////////////////////////////
         // cnl::_impl::tagged_binary_operator<nearest_rounding_tag, shift_left_op>
 
         template<>

--- a/src/test/elastic/rounding/elastic_integer_rounding.cpp
+++ b/src/test/elastic/rounding/elastic_integer_rounding.cpp
@@ -14,7 +14,7 @@ namespace {
     namespace test_shift_right_nearest {
         static_assert(
                 identical(
-                        cnl::elastic_integer<53>{14},
+                        cnl::elastic_integer<53>{7000>>9},
                         cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<62>, cnl::constant<9>>(
                                 7000,
                                 cnl::constant<9>{})),
@@ -23,7 +23,7 @@ namespace {
 #if defined(CNL_INT128_ENABLED)
         static_assert(
                 identical(
-                        cnl::elastic_integer<117>{14},
+                        cnl::elastic_integer<117>{7000>>9},
                         cnl::shift_right<cnl::nearest_rounding_tag, cnl::elastic_integer<126>, cnl::constant<9>>(
                                 7000,
                                 cnl::constant<9>{})),

--- a/src/test/rounding/rounding.cpp
+++ b/src/test/rounding/rounding.cpp
@@ -70,18 +70,18 @@ namespace {
         }
 
         namespace shift_right {
-            static_assert(identical(1, cnl::shift_right<cnl::nearest_rounding_tag>(1, 1)),
+            static_assert(identical(1>>1, cnl::shift_right<cnl::nearest_rounding_tag>(1, 1)),
                     "cnl::shift_right test failed");
-            static_assert(identical(0, cnl::shift_right<cnl::nearest_rounding_tag>(1, 2)),
+            static_assert(identical(1>>2, cnl::shift_right<cnl::nearest_rounding_tag>(1, 2)),
                     "cnl::shift_right test failed");
 
-            static_assert(identical(1, cnl::shift_right<cnl::nearest_rounding_tag>(191, 7)),
+            static_assert(identical(191>>7, cnl::shift_right<cnl::nearest_rounding_tag>(191, 7)),
                     "cnl::shift_right test failed");
-            static_assert(identical(2, cnl::shift_right<cnl::nearest_rounding_tag>(192, 7)),
+            static_assert(identical(192>>7, cnl::shift_right<cnl::nearest_rounding_tag>(192, 7)),
                     "cnl::shift_right test failed");
-            static_assert(identical(2, cnl::shift_right<cnl::nearest_rounding_tag>(319, 7)),
+            static_assert(identical(319>>7, cnl::shift_right<cnl::nearest_rounding_tag>(319, 7)),
                     "cnl::shift_right test failed");
-            static_assert(identical(3, cnl::shift_right<cnl::nearest_rounding_tag>(320, 7)),
+            static_assert(identical(320>>7, cnl::shift_right<cnl::nearest_rounding_tag>(320, 7)),
                     "cnl::shift_right test failed");
         }
     }


### PR DESCRIPTION
right-shift no longer rounds to nearest with `nearest_rounding_tag`. Resolves #418 