### PR TITLE
Ubuntu 19.04 assortment

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/include/cnl/_impl/fixed_point/named.h
+++ b/include/cnl/_impl/fixed_point/named.h
@@ -33,7 +33,7 @@ namespace cnl {
     constexpr auto make_fixed_point(Value const& value)
     -> cnl::from_value_t<fixed_point<Value, 0>, Value>
     {
-        return _impl::from_number<fixed_point<Value, 0>>(value);
+        return _impl::from_value<fixed_point<Value, 0>>(value);
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/cnl/_impl/fixed_point/type.h
+++ b/include/cnl/_impl/fixed_point/type.h
@@ -85,7 +85,7 @@ namespace cnl {
         constexpr fixed_point(fixed_point<FromRep, FromExponent, Radix> const& rhs)
                 : _base(
                 static_cast<Rep>(_impl::scale<FromExponent-exponent, Radix>(
-                        _impl::from_number<Rep>(cnl::_impl::to_rep(rhs)))))
+                        _impl::from_value<Rep>(cnl::_impl::to_rep(rhs)))))
         {
         }
 
@@ -99,7 +99,7 @@ namespace cnl {
         /// constructor taking an integer type
         template<class S, _impl::enable_if_t<numeric_limits<S>::is_integer, int> Dummy = 0>
         constexpr fixed_point(S const& s)
-                : _base(static_cast<Rep>(_impl::scale<-exponent, Radix>(_impl::from_number<Rep>(s))))
+                : _base(static_cast<Rep>(_impl::scale<-exponent, Radix>(_impl::from_value<Rep>(s))))
         {
         }
 

--- a/include/cnl/_impl/num_traits/from_value.h
+++ b/include/cnl/_impl/num_traits/from_value.h
@@ -51,7 +51,7 @@ namespace cnl {
 
     namespace _impl {
         template<typename Number, typename Value>
-        constexpr auto from_number(Value const& value)
+        constexpr auto from_value(Value const& value)
         -> decltype(cnl::from_value<Number, Value>{}(value))
         {
             return cnl::from_value<Number, Value>{}(value);
@@ -59,7 +59,7 @@ namespace cnl {
     }
 
     template<typename Number, typename Value>
-    using from_value_t = decltype(_impl::from_number<Number>(std::declval<Value>()));
+    using from_value_t = decltype(_impl::from_value<Number>(std::declval<Value>()));
 }
 
 #endif  // CNL_IMPL_NUM_TRAITS_FROM_VALUE

--- a/include/cnl/_impl/number_base.h
+++ b/include/cnl/_impl/number_base.h
@@ -148,9 +148,9 @@ namespace cnl {
                 Operator, Lhs, Rhs,
                 enable_if_t<is_wrappable<Lhs, Rhs>::value && is_derived_from_number_base<Rhs>::value>> {
             constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
-            -> decltype(Operator()(from_number<Rhs>(lhs), rhs))
+            -> decltype(Operator()(from_value<Rhs>(lhs), rhs))
             {
-                return Operator()(from_number<Rhs>(lhs), rhs);
+                return Operator()(from_value<Rhs>(lhs), rhs);
             }
         };
 
@@ -160,9 +160,9 @@ namespace cnl {
                 Operator, Lhs, Rhs,
                 enable_if_t<is_derived_from_number_base<Lhs>::value && is_wrappable<Rhs, Lhs>::value>> {
             constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
-            -> decltype(Operator()(lhs, from_number<Lhs>(rhs)))
+            -> decltype(Operator()(lhs, from_value<Lhs>(rhs)))
             {
-                return Operator()(lhs, from_number<Lhs>(rhs));
+                return Operator()(lhs, from_value<Lhs>(rhs));
             }
         };
 
@@ -199,9 +199,9 @@ namespace cnl {
                 Operator, Lhs, Rhs,
                 enable_if_t<is_wrappable<Lhs, Rhs>::value && is_derived_from_number_base<Rhs>::value>> {
             constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
-            -> decltype(Operator()(from_number<Rhs>(lhs), rhs))
+            -> decltype(Operator()(from_value<Rhs>(lhs), rhs))
             {
-                return Operator()(from_number<Rhs>(lhs), rhs);
+                return Operator()(from_value<Rhs>(lhs), rhs);
             }
         };
 
@@ -211,9 +211,9 @@ namespace cnl {
                 Operator, Lhs, Rhs,
                 enable_if_t<is_derived_from_number_base<Lhs>::value && is_wrappable<Rhs, Lhs>::value>> {
             constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
-            -> decltype(Operator()(lhs, from_number<Lhs>(rhs)))
+            -> decltype(Operator()(lhs, from_value<Lhs>(rhs)))
             {
-                return Operator()(lhs, from_number<Lhs>(rhs));
+                return Operator()(lhs, from_value<Lhs>(rhs));
             }
         };
 

--- a/include/cnl/_impl/overflow/is_overflow.h
+++ b/include/cnl/_impl/overflow/is_overflow.h
@@ -161,6 +161,12 @@ namespace cnl {
             }
         };
 
+        template<class Operator, typename ... Operands>
+        constexpr int operator_overflow_traits<Operator, Operands...>::positive_digits;
+
+        template<class Operator, typename ... Operands>
+        constexpr int operator_overflow_traits<Operator, Operands...>::negative_digits;
+
         ////////////////////////////////////////////////////////////////////////////////
         // cnl::_impl::is_overflow
 

--- a/include/cnl/elastic_integer.h
+++ b/include/cnl/elastic_integer.h
@@ -40,7 +40,7 @@ namespace cnl {
     /// the resultant type has Digits set to the sum of the operands.
     ///
     /// \sa cnl::elastic_number
-    template<int Digits, class Narrowest>
+    template<int Digits = digits<int>::value, class Narrowest = int>
     class elastic_integer;
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -169,7 +169,7 @@ namespace cnl {
         }
     };
 
-    template<int Digits = digits<int>::value, class Narrowest = int>
+    template<int Digits, class Narrowest>
     class elastic_integer : public _elastic_integer_impl::base_class_t<Digits, Narrowest> {
     public:
         using _base = _elastic_integer_impl::base_class_t<Digits, Narrowest>;

--- a/include/cnl/elastic_number.h
+++ b/include/cnl/elastic_number.h
@@ -13,6 +13,7 @@
 #include "elastic_integer.h"
 #include "fixed_point.h"
 #include "limits.h"
+#include "_impl/num_traits/adopt_signedness.h"
 
 #include <type_traits>
 

--- a/src/test/_impl/wide_integer/from_value.cpp
+++ b/src/test/_impl/wide_integer/from_value.cpp
@@ -23,6 +23,6 @@ namespace {
     static_assert(
             identical(
                     cnl::_impl::wide_integer<64, unsigned>{654},
-                    cnl::_impl::from_number<cnl::_impl::wide_integer<>>(UINT64_C(654))),
-            "cnl::from_number<cnl::_impl::wide_integer>");
+                    cnl::_impl::from_value<cnl::_impl::wide_integer<>>(UINT64_C(654))),
+            "cnl::from_value<cnl::_impl::wide_integer>");
 }

--- a/src/test/_impl/wide_integer/literals.cpp
+++ b/src/test/_impl/wide_integer/literals.cpp
@@ -63,7 +63,7 @@ namespace {
                         123456789_wide),
                 "");
 
-#if !defined(_MSC_VER) && (defined(__clang__) || !defined(__GNUG__) || __GNUG__ < 7)
+#if defined(__clang__) || defined(CNL_INT128_ENABLED)
         // requires that constexpr-steps is set very high
         static_assert(
                 identical(

--- a/src/test/_impl/wide_integer/operators.cpp
+++ b/src/test/_impl/wide_integer/operators.cpp
@@ -104,7 +104,7 @@ namespace {
                                 cnl::_impl::wide_integer<16, signed>>{}(0x1234, 0x100)),
                 "");
 
-#if !defined(_MSC_VER) && (defined(__clang__) || !defined(__GNUG__) || __GNUG__ < 7)
+#if defined(__clang__) || defined(CNL_INT128_ENABLED)
         TEST(wide_integer, divide)
         {
             using namespace cnl::_impl;

--- a/src/test/elastic/elastic_integer.cpp
+++ b/src/test/elastic/elastic_integer.cpp
@@ -95,30 +95,30 @@ namespace {
     namespace test_impl_make_number {
         static_assert(identical(
                 elastic_integer<cnl::digits<int>::value>{14},
-                cnl::_impl::from_number<elastic_integer<>>(14)),
-                "cnl::_impl::from_number<elastic_integer> test failed");
+                cnl::_impl::from_value<elastic_integer<>>(14)),
+                "cnl::_impl::from_value<elastic_integer> test failed");
         static_assert(
                 identical(
                         elastic_integer<cnl::digits<int>::value>{22},
-                        cnl::_impl::from_number<elastic_integer<>>(elastic_integer<>{22})),
-                "cnl::_impl::from_number<elastic_integer> test failed");
+                        cnl::_impl::from_value<elastic_integer<>>(elastic_integer<>{22})),
+                "cnl::_impl::from_value<elastic_integer> test failed");
 
-        static_assert(identical(cnl::_impl::from_number<elastic_integer<>>(0_c), elastic_integer<0>{0}),
-                "cnl::_impl::from_number<elastic_integer> test failed");
-        static_assert(identical(cnl::_impl::from_number<elastic_integer<>>(1_c), elastic_integer<1>{1}),
-                "cnl::_impl::from_number<elastic_integer> test failed");
-        static_assert(identical(cnl::_impl::from_number<elastic_integer<>>(14_c), elastic_integer<4>{14}),
-                "cnl::_impl::from_number<elastic_integer> test failed");
-        static_assert(identical(cnl::_impl::from_number<elastic_integer<>>(-31_c), elastic_integer<5>{-31}),
-                "cnl::_impl::from_number<elastic_integer> test failed");
-        static_assert(identical(cnl::_impl::from_number<elastic_integer<>>(-32_c), elastic_integer<6>{-32}),
-                "cnl::_impl::from_number<elastic_integer> test failed");
+        static_assert(identical(cnl::_impl::from_value<elastic_integer<>>(0_c), elastic_integer<0>{0}),
+                "cnl::_impl::from_value<elastic_integer> test failed");
+        static_assert(identical(cnl::_impl::from_value<elastic_integer<>>(1_c), elastic_integer<1>{1}),
+                "cnl::_impl::from_value<elastic_integer> test failed");
+        static_assert(identical(cnl::_impl::from_value<elastic_integer<>>(14_c), elastic_integer<4>{14}),
+                "cnl::_impl::from_value<elastic_integer> test failed");
+        static_assert(identical(cnl::_impl::from_value<elastic_integer<>>(-31_c), elastic_integer<5>{-31}),
+                "cnl::_impl::from_value<elastic_integer> test failed");
+        static_assert(identical(cnl::_impl::from_value<elastic_integer<>>(-32_c), elastic_integer<6>{-32}),
+                "cnl::_impl::from_value<elastic_integer> test failed");
 
 #if defined(CNL_INT128_ENABLED)
         static_assert(identical(
-                cnl::_impl::from_number<elastic_integer<0>>(-0x10000000000000000000000000000000_c),
+                cnl::_impl::from_value<elastic_integer<0>>(-0x10000000000000000000000000000000_c),
                 elastic_integer<125>{-CNL_INTMAX_C(0x10000000000000000000000000000000)}),
-                "cnl::_impl::from_number<elastic_integer> test failed");
+                "cnl::_impl::from_value<elastic_integer> test failed");
 #endif
     }
 
@@ -128,19 +128,19 @@ namespace {
         static_assert(std::is_same<elastic_integer<7, int>::rep, int>::value, "");
         static_assert(identical(
                 elastic_integer<cnl::numeric_limits<int>::digits>{1},
-                cnl::_impl::from_number<elastic_integer<3>>(1)), "elastic_integer test failed");
-        static_assert(identical(cnl::_impl::from_number<elastic_integer<3>>(1),
+                cnl::_impl::from_value<elastic_integer<3>>(1)), "elastic_integer test failed");
+        static_assert(identical(cnl::_impl::from_value<elastic_integer<3>>(1),
                 elastic_integer<cnl::numeric_limits<int>::digits>{1}), "elastic_integer test failed");
-        static_assert(identical(cnl::_impl::from_number<elastic_integer<1>>(INT32_C(0)), elastic_integer<31>{0}),
+        static_assert(identical(cnl::_impl::from_value<elastic_integer<1>>(INT32_C(0)), elastic_integer<31>{0}),
                 "cnl::elastic_integer test failed");
 
         static_assert(identical(
                 cnl::elastic_integer<3, signed>{6},
-                cnl::_impl::from_number<cnl::elastic_integer<2, unsigned>>(cnl::constant<6>{})),
+                cnl::_impl::from_value<cnl::elastic_integer<2, unsigned>>(cnl::constant<6>{})),
                 "from_value<elastic_integer, constant>");
         static_assert(identical(
                 cnl::elastic_integer<3, signed>{6},
-                cnl::_impl::from_number<cnl::elastic_integer<2, signed>>(cnl::constant<6>{})),
+                cnl::_impl::from_value<cnl::elastic_integer<2, signed>>(cnl::constant<6>{})),
                 "from_value<elastic_integer, constant>");
         static_assert(
                 assert_same<

--- a/src/test/fixed_point/decimal.cpp
+++ b/src/test/fixed_point/decimal.cpp
@@ -20,7 +20,7 @@ namespace test_ctor_int {
 namespace test_from_value {
     static_assert(identical(
             decimal_fixed_point<int, 0>{123},
-            cnl::_impl::from_number<decimal_fixed_point<int, 1>>(123)), "");
+            cnl::_impl::from_value<decimal_fixed_point<int, 1>>(123)), "");
 }
 
 namespace test_from_rep {

--- a/src/test/fixed_point/fixed_point_common.h
+++ b/src/test/fixed_point/fixed_point_common.h
@@ -332,15 +332,15 @@ namespace test_from_rep {
 }
 
 namespace test_impl_make_number {
-    static_assert(identical(fixed_point<short>{123}, cnl::_impl::from_number<fixed_point<long long>>(short{123})),
-            "cnl::_impl::from_number<fixed_point<>>");
-    static_assert(identical(fixed_point<std::uint64_t>{404}, cnl::_impl::from_number<fixed_point<>>(UINT64_C(404))),
-            "cnl::_impl::from_number<fixed_point<>, cnl::constant<4>>()");
+    static_assert(identical(fixed_point<short>{123}, cnl::_impl::from_value<fixed_point<long long>>(short{123})),
+            "cnl::_impl::from_value<fixed_point<>>");
+    static_assert(identical(fixed_point<std::uint64_t>{404}, cnl::_impl::from_value<fixed_point<>>(UINT64_C(404))),
+            "cnl::_impl::from_value<fixed_point<>, cnl::constant<4>>()");
 
-    static_assert(identical(cnl::_impl::from_number<fixed_point<int32>>(cnl::constant<369>{}), fixed_point<int>{369}),
-            "cnl::_impl::from_number<fixed_point<>>");
-    static_assert(identical(fixed_point<int, 2>{4}, cnl::_impl::from_number<fixed_point<>>(cnl::constant<4>{})),
-            "cnl::_impl::from_number<fixed_point<>, cnl::constant<4>>()");
+    static_assert(identical(cnl::_impl::from_value<fixed_point<int32>>(cnl::constant<369>{}), fixed_point<int>{369}),
+            "cnl::_impl::from_value<fixed_point<>>");
+    static_assert(identical(fixed_point<int, 2>{4}, cnl::_impl::from_value<fixed_point<>>(cnl::constant<4>{})),
+            "cnl::_impl::from_value<fixed_point<>, cnl::constant<4>>()");
 }
 
 #if defined(__cpp_deduction_guides)

--- a/src/test/integer/from_value.cpp
+++ b/src/test/integer/from_value.cpp
@@ -23,6 +23,6 @@ namespace {
     static_assert(
             identical(
                     cnl::_impl::integer<unsigned long long>{654},
-                    cnl::_impl::from_number<cnl::_impl::integer<>>(654ULL)),
-            "cnl::from_number<cnl::_impl::integer>");
+                    cnl::_impl::from_value<cnl::_impl::integer<>>(654ULL)),
+            "cnl::from_value<cnl::_impl::integer>");
 }

--- a/src/test/num_traits.cpp
+++ b/src/test/num_traits.cpp
@@ -30,54 +30,54 @@ namespace {
         static_assert(identical(cnl::from_value_t<cnl::uint128, int>{123}, 123), "cnl::from_value_t<cnl::uint128, int>");
         static_assert(
                 identical(
-                        cnl::_impl::from_number<cnl::uint128>(123),
+                        cnl::_impl::from_value<cnl::uint128>(123),
                         123),
-                "cnl::_impl::from_number<cnl::uint128>");
+                "cnl::_impl::from_value<cnl::uint128>");
 #endif
 
-        static_assert(identical(cnl::_impl::from_number<cnl::uint8>(123), 123), "cnl::_impl::from_number<cnl::uint8>");
+        static_assert(identical(cnl::_impl::from_value<cnl::uint8>(123), 123), "cnl::_impl::from_value<cnl::uint8>");
         static_assert(identical(
-                cnl::_impl::from_number<cnl::uint64>(cnl::int8{123}),
-                cnl::int8{123}), "cnl::_impl::from_number<cnl::uint64>(cnl::int8)");
+                cnl::_impl::from_value<cnl::uint64>(cnl::int8{123}),
+                cnl::int8{123}), "cnl::_impl::from_value<cnl::uint64>(cnl::int8)");
 
-        static_assert(identical(cnl::_impl::from_number<long>(123LL), 123LL), "cnl::_impl::from_number<cnl::uint8>");
+        static_assert(identical(cnl::_impl::from_value<long>(123LL), 123LL), "cnl::_impl::from_value<cnl::uint8>");
         static_assert(
                 identical(
-                        cnl::_impl::from_number<long long>(123LL),
+                        cnl::_impl::from_value<long long>(123LL),
                         123LL),
-                "cnl::_impl::from_number<cnl::uint8>");
-        static_assert(identical(cnl::_impl::from_number<long>(123L), 123L), "cnl::_impl::from_number<cnl::uint8>");
-        static_assert(identical(cnl::_impl::from_number<long long>(123L), 123L), "cnl::_impl::from_number<cnl::uint8>");
+                "cnl::_impl::from_value<cnl::uint8>");
+        static_assert(identical(cnl::_impl::from_value<long>(123L), 123L), "cnl::_impl::from_value<cnl::uint8>");
+        static_assert(identical(cnl::_impl::from_value<long long>(123L), 123L), "cnl::_impl::from_value<cnl::uint8>");
 
-        static_assert(identical(std::int16_t{123}, cnl::_impl::from_number<std::int16_t>(std::int16_t{123})),
-                "cnl::_impl::from_number<std::int16_t, std::int16_t>");
-        static_assert(identical(std::int32_t{123}, cnl::_impl::from_number<std::int16_t>(std::int32_t{123})),
-                "cnl::_impl::from_number<std::int16_t, std::int32_t>");
-        static_assert(identical(std::int64_t{123}, cnl::_impl::from_number<std::int16_t>(std::int64_t{123})),
-                "cnl::_impl::from_number<std::int16_t, std::int64_t>");
-        static_assert(identical(std::int16_t{123}, cnl::_impl::from_number<std::int32_t>(std::int16_t{123})),
-                "cnl::_impl::from_number<std::int32_t, std::int16_t>");
-        static_assert(identical(std::int32_t{123}, cnl::_impl::from_number<std::int32_t>(std::int32_t{123})),
-                "cnl::_impl::from_number<std::int32_t, std::int32_t>");
-        static_assert(identical(std::int64_t{123}, cnl::_impl::from_number<std::int32_t>(std::int64_t{123})),
-                "cnl::_impl::from_number<std::int32_t, std::int64_t>");
-        static_assert(identical(std::int16_t{123}, cnl::_impl::from_number<std::int64_t>(std::int16_t{123})),
-                "cnl::_impl::from_number<std::int64_t, std::int16_t>");
-        static_assert(identical(std::int32_t{123}, cnl::_impl::from_number<std::int64_t>(std::int32_t{123})),
-                "cnl::_impl::from_number<std::int64_t, std::int32_t>");
-        static_assert(identical(std::int64_t{123}, cnl::_impl::from_number<std::int64_t>(std::int64_t{123})),
-                "cnl::_impl::from_number<std::int64_t, std::int64_t>");
+        static_assert(identical(std::int16_t{123}, cnl::_impl::from_value<std::int16_t>(std::int16_t{123})),
+                "cnl::_impl::from_value<std::int16_t, std::int16_t>");
+        static_assert(identical(std::int32_t{123}, cnl::_impl::from_value<std::int16_t>(std::int32_t{123})),
+                "cnl::_impl::from_value<std::int16_t, std::int32_t>");
+        static_assert(identical(std::int64_t{123}, cnl::_impl::from_value<std::int16_t>(std::int64_t{123})),
+                "cnl::_impl::from_value<std::int16_t, std::int64_t>");
+        static_assert(identical(std::int16_t{123}, cnl::_impl::from_value<std::int32_t>(std::int16_t{123})),
+                "cnl::_impl::from_value<std::int32_t, std::int16_t>");
+        static_assert(identical(std::int32_t{123}, cnl::_impl::from_value<std::int32_t>(std::int32_t{123})),
+                "cnl::_impl::from_value<std::int32_t, std::int32_t>");
+        static_assert(identical(std::int64_t{123}, cnl::_impl::from_value<std::int32_t>(std::int64_t{123})),
+                "cnl::_impl::from_value<std::int32_t, std::int64_t>");
+        static_assert(identical(std::int16_t{123}, cnl::_impl::from_value<std::int64_t>(std::int16_t{123})),
+                "cnl::_impl::from_value<std::int64_t, std::int16_t>");
+        static_assert(identical(std::int32_t{123}, cnl::_impl::from_value<std::int64_t>(std::int32_t{123})),
+                "cnl::_impl::from_value<std::int64_t, std::int32_t>");
+        static_assert(identical(std::int64_t{123}, cnl::_impl::from_value<std::int64_t>(std::int64_t{123})),
+                "cnl::_impl::from_value<std::int64_t, std::int64_t>");
 
         // assumes that int === int32_t
-        static_assert(identical(123, cnl::_impl::from_number<std::int16_t>(cnl::constant<123>{})),
-                "cnl::_impl::from_number<std::int16_t, cnl::constant<std::int64_t>>");
-        static_assert(identical(123, cnl::_impl::from_number<std::int64_t>(cnl::constant<123>{})),
-                "cnl::_impl::from_number<std::int64_t, cnl::constant<std::int64_t>>");
+        static_assert(identical(123, cnl::_impl::from_value<std::int16_t>(cnl::constant<123>{})),
+                "cnl::_impl::from_value<std::int16_t, cnl::constant<std::int64_t>>");
+        static_assert(identical(123, cnl::_impl::from_value<std::int64_t>(cnl::constant<123>{})),
+                "cnl::_impl::from_value<std::int64_t, cnl::constant<std::int64_t>>");
         static_assert(
                 identical(
                         INT64_C(0x123456789abcdef),
-                        cnl::_impl::from_number<std::int16_t>(cnl::constant<0x123456789abcdef>{})),
-                "cnl::_impl::from_number<std::int16_t, cnl::constant<std::int64_t>>");
+                        cnl::_impl::from_value<std::int16_t>(cnl::constant<0x123456789abcdef>{})),
+                "cnl::_impl::from_value<std::int16_t, cnl::constant<std::int64_t>>");
     }
 
     namespace test_set_digits {

--- a/src/test/overflow/overflow_integer.cpp
+++ b/src/test/overflow/overflow_integer.cpp
@@ -76,7 +76,7 @@ static_assert(is_overflow_integer<saturated_integer<int64_t>>::value,
 
 // equality
 
-static_assert(identical(saturated_integer<int>(1234), cnl::_impl::from_number<saturated_integer<uint8_t>>(1234)),
+static_assert(identical(saturated_integer<int>(1234), cnl::_impl::from_value<saturated_integer<uint8_t>>(1234)),
               "cnl::from_value<cnl::saturated_integer> test failed");
 static_assert(cnl::_impl::comparison_operator<cnl::_impl::equal_op, saturated_integer<uint8_t>, int>()(
         saturated_integer<uint8_t>(-1), 0), "cnl::saturated_integer equality test failed");
@@ -423,13 +423,13 @@ namespace test_impl_from_rep {
 namespace test_from_value {
     static_assert(identical(
             native_integer<long long>{746352},
-            cnl::_impl::from_number<native_integer<int>>(746352LL)), "");
+            cnl::_impl::from_value<native_integer<int>>(746352LL)), "");
     static_assert(identical(
             746352LL,
-            cnl::_impl::from_number<int>(746352LL)), "");
+            cnl::_impl::from_value<int>(746352LL)), "");
     static_assert(identical(
             native_integer<long long>{746352},
-            cnl::_impl::from_number<native_integer<int>>(native_integer<long long>{746352})), "");
+            cnl::_impl::from_value<native_integer<int>>(native_integer<long long>{746352})), "");
 }
 
 namespace test_minus {

--- a/src/test/rounding/rounding_integer.cpp
+++ b/src/test/rounding/rounding_integer.cpp
@@ -128,14 +128,14 @@ namespace {
             static_assert(
                     identical(
                     rounding_integer<long long>{9876543210LL},
-                            cnl::_impl::from_number<rounding_integer<long>>(9876543210LL)),
-                    "cnl::_impl::from_number<rounding_integer> test failed");
+                            cnl::_impl::from_value<rounding_integer<long>>(9876543210LL)),
+                    "cnl::_impl::from_value<rounding_integer> test failed");
             static_assert(
                     identical(
                             rounding_integer<long long>{9876543210LL},
-                            cnl::_impl::from_number<rounding_integer<short>>(
+                            cnl::_impl::from_value<rounding_integer<short>>(
                                     rounding_integer<long long>{9876543210LL})),
-                    "cnl::_impl::from_number<rounding_integer> test failed");
+                    "cnl::_impl::from_value<rounding_integer> test failed");
         }
     }
     

--- a/src/test/vc.cpp
+++ b/src/test/vc.cpp
@@ -45,13 +45,13 @@ namespace {
 
     TEST(vc, from_value_of_i) {
         auto i = 123;
-        auto a = cnl::_impl::from_number<Vc::simd<std::uint16_t>>(i);
+        auto a = cnl::_impl::from_value<Vc::simd<std::uint16_t>>(i);
         EXPECT_TRUE(simd_identical(Vc::simd<int>{123}, a));
     }
 
     TEST(vc, from_value_of_simd_of_i) {
         auto s = Vc::simd<int>{123};
-        auto a = cnl::_impl::from_number<Vc::simd<int>>(s);
+        auto a = cnl::_impl::from_value<Vc::simd<int>>(s);
         EXPECT_TRUE(simd_identical(Vc::simd<int>{123}, a));
     }
 


### PR DESCRIPTION
* Renames `from_number` to `from_value`.
* Fixes compiler errors/slowdowns when using latest GCC6 that comes with latest Ubuntu.
* Minor fixes to *elastic_integer.h*.