### PR TITLE
Increase minimum software requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Tested on x86-86 using  [Travis](https://travis-ci.org/johnmcfarlane/cnl) and
 
 Requires:
 
-- GCC 5.1 / Clang 3.5
+- GCC 5.1 / Clang 3.8
 
 Optional:
 
-- [CMake](https://cmake.org/download/) ([3.0.2](https://docs.travis-ci.com/user/languages/cpp/#CMake))
+- [CMake](https://cmake.org/download/) ([3.7.2](https://docs.travis-ci.com/user/languages/cpp/#CMake))
 - [Boost](http://www.boost.org/) - facilitates multiprecision support
 - [Doxygen](http://www.doxygen.org/) - generates documentation in the *doc/gh-pages* directory
 


### PR DESCRIPTION
Minimum Clang version is now 3.8 due to N3922

- CMake (optional) is now only tested on 3.7.2 and above.