### PR TITLE
Fix to another out-of-nowhere OS X Brew failure

### DIFF
--- a/.travis/test-osx.sh
+++ b/.travis/test-osx.sh
@@ -10,6 +10,7 @@ PROJECT_SOURCE_DIR="${TRAVIS_BUILD_DIR}"
 
 # Before install
 brew update
+brew unlink python@2
 
 # Install
 brew install ccache cloc conan ${PACKAGE}


### PR DESCRIPTION
- perhaps as a result of moves away from Python 2.x
- solution came as part of a brew error message
  - but not before following suggestion here:
    https://stackoverflow.com/questions/13354207/how-to-symlink-python-in-homebrew/13354417#13354417