### PR TITLE
Use simpler variable for hooking CMake->Conan

### DIFF
--- a/test/scripts/bits/config.sh
+++ b/test/scripts/bits/config.sh
@@ -20,7 +20,7 @@ conan install \
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-  -DCMAKE_PROJECT_cnl_INCLUDE:FILEPATH="$(pwd)"/conan_paths.cmake \
+  -DCMAKE_PROJECT_INCLUDE:FILEPATH="$(pwd)"/conan_paths.cmake \
   -G Ninja \
   "$@" \
   "${PROJECT_DIR}"


### PR DESCRIPTION
`CMAKE_PROJECT_INCLUDE` instead of `CMAKE_PROJECT_cnl_INCLUDE` as this is a single-project repo.