### PR TITLE
Remove superfluous config flags

### DIFF
--- a/test/scripts/bits/config.sh
+++ b/test/scripts/bits/config.sh
@@ -14,11 +14,9 @@ cloc "${PROJECT_DIR}"/test
 
 conan install \
   --build=missing \
-  --settings build_type=Release \
   "${PROJECT_DIR}"
 
 cmake \
-  -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCMAKE_PROJECT_INCLUDE:FILEPATH="$(pwd)"/conan_paths.cmake \
   -G Ninja \


### PR DESCRIPTION
Both Conan and CMake default build type is _Release_ already.
No need to re-specify the defaults here.