### PR TITLE
Adds the missing division to tie_to_pos_inf_rounding

### DIFF
--- a/include/cnl/_impl/rounding.h
+++ b/include/cnl/_impl/rounding.h
@@ -17,6 +17,7 @@
 #include "rounding/convert_operator.h"
 #include "rounding/native_rounding_tag.h"
 #include "rounding/nearest_rounding_tag.h"
+#include "rounding/tie_to_pos_inf_rounding_tag.h"
 
 /// compositional numeric library
 namespace cnl {

--- a/include/cnl/_impl/rounding/tie_to_pos_inf_rounding_tag.h
+++ b/include/cnl/_impl/rounding/tie_to_pos_inf_rounding_tag.h
@@ -7,6 +7,12 @@
 #if !defined(CNL_IMPL_ROUNDING_TIE_TO_POS_INF_ROUNDING_TAG_H)
 #define CNL_IMPL_ROUNDING_TIE_TO_POS_INF_ROUNDING_TAG_H
 
+#include "../operators/generic.h"
+#include "../operators/native_tag.h"
+#include "is_rounding_tag.h"
+
+#include <type_traits>
+
 /// compositional numeric library
 namespace cnl {
     /// \brief tag to specify tie to positive inf rounding behavior in arithmetic operations
@@ -18,7 +24,64 @@ namespace cnl {
     /// \sa cnl::rounding_integer,
     /// cnl::add, cnl::convert, cnl::divide, cnl::left_shift, cnl::multiply, cnl::subtract,
     /// cnl::tie_to_pos_inf_rounding_tag
-    struct tie_to_pos_inf_rounding_tag {
+    struct tie_to_pos_inf_rounding_tag
+            : _impl::homogeneous_deduction_tag_base, _impl::homogeneous_operator_tag_base {
+    };
+
+    namespace _impl {
+        template<>
+        struct is_rounding_tag<tie_to_pos_inf_rounding_tag> : std::true_type {
+        };
+    }
+
+    template<class Operator, typename Operand>
+    struct unary_operator<Operator, tie_to_pos_inf_rounding_tag, Operand>
+            : unary_operator<Operator, _impl::native_tag, Operand> {
+    };
+
+    template<class Operator, typename Lhs, typename Rhs>
+    struct binary_operator<Operator, tie_to_pos_inf_rounding_tag, tie_to_pos_inf_rounding_tag, Lhs, Rhs>
+            : Operator {
+    };
+
+    template<typename Lhs, typename Rhs>
+    struct binary_operator<_impl::divide_op, tie_to_pos_inf_rounding_tag, tie_to_pos_inf_rounding_tag, Lhs, Rhs> {
+    private:
+        CNL_NODISCARD constexpr auto myabs(Lhs const& lhs) const
+        {
+            return lhs < 0 ? -lhs : lhs;
+        }
+        CNL_NODISCARD constexpr auto step2(Lhs const& lhs, Rhs const& rhs) const
+        {
+            return (lhs < 0)
+            ? -((myabs(lhs) + (rhs - (lhs < 0 ? 1 : 0))/2) / rhs)
+            : (myabs(lhs) + (rhs - (lhs < 0 ? 1 : 0))/2) / rhs;
+        }
+        CNL_NODISCARD constexpr auto step1(Lhs const& lhs, Rhs const& rhs) const
+        {
+            return (rhs < 0) ? step2(-lhs, -rhs) : step2(lhs, rhs);
+        }
+    public:
+        CNL_NODISCARD constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
+        -> decltype(lhs/rhs)
+        {
+            return step1(lhs, rhs);
+        }
+    };
+
+    template<class Operator, class RhsTag, typename Lhs, typename Rhs>
+    struct shift_operator<Operator, tie_to_pos_inf_rounding_tag, RhsTag, Lhs, Rhs>
+            : Operator {
+    };
+
+    template<class Operator, typename Rhs>
+    struct pre_operator<Operator, tie_to_pos_inf_rounding_tag, Rhs>
+            : Operator {
+    };
+
+    template<class Operator, typename Rhs>
+    struct post_operator<Operator, tie_to_pos_inf_rounding_tag, Rhs>
+            : Operator {
     };
 }
 

--- a/test/unit/rounding/rounding.cpp
+++ b/test/unit/rounding/rounding.cpp
@@ -123,4 +123,80 @@ namespace {
                     "cnl::shift_right test failed");
         }
     }
+
+    namespace tie_to_pos_inf_rounding {
+
+        namespace convert {
+            static_assert(
+                    identical(
+                            cnl::uint8{101},
+                            cnl::convert<cnl::tie_to_pos_inf_rounding_tag, cnl::_impl::native_tag, cnl::uint8>(100.5)),
+                    "cnl::convert test failed");
+            static_assert(
+                    identical(
+                            cnl::int16{-1000},
+                            cnl::convert<cnl::tie_to_pos_inf_rounding_tag, cnl::_impl::native_tag, cnl::int16>(
+                                    -1000.5L)),
+                    "cnl::convert test failed");
+            static_assert(
+                    identical(
+                            55,
+                            cnl::convert<cnl::tie_to_pos_inf_rounding_tag, cnl::_impl::native_tag, cnl::int32>(55.2F)),
+                    "cnl::convert test failed");
+            static_assert(
+                    identical(
+                            -0,
+                            cnl::convert<cnl::tie_to_pos_inf_rounding_tag, cnl::_impl::native_tag, int>(-0.50)),
+                    "cnl::convert test failed");
+            static_assert(
+                    identical(
+                            -0,
+                            cnl::convert<cnl::tie_to_pos_inf_rounding_tag, cnl::_impl::native_tag, int>(-0.49)),
+                    "cnl::convert test failed");
+            static_assert(
+                    identical(
+                            +0,
+                            cnl::convert<cnl::tie_to_pos_inf_rounding_tag, cnl::_impl::native_tag, int>(0.49)),
+                    "cnl::convert test failed");
+            static_assert(
+                    identical(
+                            +1,
+                            cnl::convert<cnl::tie_to_pos_inf_rounding_tag, cnl::_impl::native_tag, int>(0.50)),
+                    "cnl::convert test failed");
+        }
+
+        namespace divide {
+            static_assert(identical(-1, cnl::divide<cnl::tie_to_pos_inf_rounding_tag>(-990, 661)),
+                    "cnl::divide test failed");
+            static_assert(identical(2, cnl::divide<cnl::tie_to_pos_inf_rounding_tag>(-606, -404)),
+                    "cnl::divide test failed");
+            static_assert(identical(1, cnl::divide<cnl::tie_to_pos_inf_rounding_tag>(8, 9)),
+                    "cnl::divide test failed");
+            static_assert(identical(-1, cnl::divide<cnl::tie_to_pos_inf_rounding_tag>(9, -8)),
+                    "cnl::divide test failed");
+            static_assert(identical(-1, cnl::divide<cnl::tie_to_pos_inf_rounding_tag>(-9, 6)),
+                    "cnl::divide test failed");
+            static_assert(identical(1, cnl::divide<cnl::tie_to_pos_inf_rounding_tag>(-9, -7)),
+                    "cnl::divide test failed");
+            static_assert(identical(2, cnl::divide<cnl::tie_to_pos_inf_rounding_tag, cnl::uint16, int>(999, 666)),
+                    "cnl::divide test failed");
+            static_assert(identical(1LL, cnl::divide<cnl::tie_to_pos_inf_rounding_tag>(998, 666LL)),
+                    "cnl::divide test failed");
+        }
+
+        namespace shift_right {
+            static_assert(identical(1 >> 1, cnl::shift_right<cnl::tie_to_pos_inf_rounding_tag>(1, 1)),
+                    "cnl::shift_right test failed");
+            static_assert(identical(1 >> 2, cnl::shift_right<cnl::tie_to_pos_inf_rounding_tag>(1, 2)),
+                    "cnl::shift_right test failed");
+            static_assert(identical(191 >> 7, cnl::shift_right<cnl::tie_to_pos_inf_rounding_tag>(191, 7)),
+                    "cnl::shift_right test failed");
+            static_assert(identical(192 >> 7, cnl::shift_right<cnl::tie_to_pos_inf_rounding_tag>(192, 7)),
+                    "cnl::shift_right test failed");
+            static_assert(identical(319 >> 7, cnl::shift_right<cnl::tie_to_pos_inf_rounding_tag>(319, 7)),
+                    "cnl::shift_right test failed");
+            static_assert(identical(320 >> 7, cnl::shift_right<cnl::tie_to_pos_inf_rounding_tag>(320, 7)),
+                    "cnl::shift_right test failed");
+        }
+    }
 }


### PR DESCRIPTION
Found the missing division to tie_to_pos_inf_rounding, thus the tie value is rounded towards positive infinity. Otherwise to nearest. Possibly better algorithms exists.