### PR TITLE
Allow deployment to happen from any branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
           skip_cleanup: true
           verbose: true
           on:
-            branch: main
+            all_branches: true
             condition: $TRAVIS_BRANCH =~ ^v([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)$
 
     - name: Linux/ShellCheck, Shell script lint


### PR DESCRIPTION
- In reality, we want deployment only from the main branch, but
  - Travis-CI treats tags as branches
    when they are used to trigger a build.