### PR TITLE
Bump gtest to current head in cmake-test-gcc Circle CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,9 @@ jobs:
       - run:
           name: Build/install GTest
           command: >
-            git clone --branch release-1.10.0 https://github.com/google/googletest.git &&
+            git clone https://github.com/google/googletest.git &&
             cd googletest &&
+            git checkout 3c95bf552405fd0cc63cea0ca2f6c4cd89c8d356 &&
             mkdir build &&
             cd build &&
             cmake .. &&


### PR DESCRIPTION
GCC head appears not to work with GTest 1.10.0:

In file included from /root/project/googletest/googletest/src/gtest-all.cc:42:
/root/project/googletest/googletest/src/gtest-death-test.cc: In function 'bool testing::internal::StackGrowsDown()':
/root/project/googletest/googletest/src/gtest-death-test.cc:1301:24: error: 'dummy' may be used uninitialized [-Werror=maybe-uninitialized]
 1301 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~

https://app.circleci.com/pipelines/github/johnmcfarlane/cnl/545/workflows/b2c40722-d238-436d-baeb-b12fdd9601f0/jobs/9448