### PR TITLE
Fix Doxygen deployment version

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -11,15 +11,18 @@ PROJECT_DIR=$(
 regex='^refs\/tags\/v([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)$'
 
 # Extract Semver from Git tag.
-echo "Tag: ${CNL_VERSION}"
-if [[ "${CNL_VERSION}" =~ $regex ]]
+echo "Tag: ${CNL_VERSION_TAG}"
+if [[ "${CNL_VERSION_TAG}" =~ $regex ]]
 then
-    export version="${BASH_REMATCH[1]}"
-    echo "CNL version ${version}"
+    export CNL_VERSION="${BASH_REMATCH[1]}"
+    echo "CNL version ${CNL_VERSION}"
 else
-    echo "Tag ${CNL_VERSION} not recognized as Semver version tag"
+    echo "Tag ${CNL_VERSION_TAG} not recognized as Semver version tag"
     exit 1
 fi
+
+# Generate documentation
+"${PROJECT_DIR}/doc/generate.sh"
 
 # Push revision of documentation
 pushd "${PROJECT_DIR}/doc/gh-pages"
@@ -29,7 +32,7 @@ git remote set-url origin "https://johnmcfarlane:${GITHUB_TOKEN}@github.com/john
 git reset origin/gh-pages
 git checkout gh-pages
 git add .
-if git commit -m"Documentation v${version}"
+if git commit -m"Documentation v${CNL_VERSION}"
 then
   git push
 fi
@@ -39,5 +42,5 @@ popd
 conan remote add --force johnmcfarlane/cnl https://api.bintray.com/conan/johnmcfarlane/cnl
 conan user -p "${CONAN_PASS}" -r johnmcfarlane/cnl "${CONAN_USER}"
 conan install --build=missing "${PROJECT_DIR}"
-conan create . "cnl/${version}@johnmcfarlane/development"
-conan upload "cnl/${version}@johnmcfarlane/development" -r johnmcfarlane/cnl
+conan create "${PROJECT_DIR}" "cnl/${CNL_VERSION}@johnmcfarlane/development"
+conan upload "cnl/${CNL_VERSION}@johnmcfarlane/development" -r johnmcfarlane/cnl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,14 +16,10 @@ jobs:
         fetch-depth: 0
         submodules: true
 
-    - name: Generate documentation
-      shell: bash
-      run: $GITHUB_WORKSPACE/doc/generate.sh
-
     - name: Deploy
       shell: bash
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         CONAN_PASS: ${{secrets.BINTRAY_API_KEY}}
         CONAN_USER: ${{secrets.BINTRAY_USERNAME}}
-      run: CNL_VERSION=$GITHUB_REF $GITHUB_WORKSPACE/.github/deploy.sh
+      run: CNL_VERSION_TAG=$GITHUB_REF $GITHUB_WORKSPACE/.github/deploy.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [push]
+on: 
+  push:
+    branches:
+      - '**'
 
 jobs:
   # Build and test many combinations on Linux/OS X using Conan


### PR DESCRIPTION
.github/deploy.yml wasn't using CNL_VERSION when running doc/generage.sh,
which wasn't correctly parsed anyway. Now doc/generate.sh is invoked from
.github/deploy.sh with correct value for CNL_VERSION.

Result is that documentation published to johnmcfarlane.github.io/cnl/ has
correct version extracted from Git tag -- rather than fallback label,
"development".