### PR TITLE
Use to_string for operator<< w. fraction

### DIFF
--- a/include/cnl/_impl/fraction/operators.h
+++ b/include/cnl/_impl/fraction/operators.h
@@ -8,6 +8,7 @@
 #define CNL_IMPL_FRACTION_OPERATORS_H
 
 #include "make_fraction.h"
+#include "to_string.h"
 #include "type.h"
 
 #include <ostream>
@@ -137,7 +138,7 @@ namespace cnl {
     template<typename Numerator, typename Denominator>
     ::std::ostream& operator<<(::std::ostream& out, fraction<Numerator, Denominator> const& f)
     {
-        return out << f.numerator << '/' << f.denominator;
+        return out << to_string(f);
     }
 }
 

--- a/test/unit/fraction/fraction.cpp
+++ b/test/unit/fraction/fraction.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 namespace {
     using cnl::_impl::assert_same;
     using cnl::_impl::identical;
@@ -209,5 +211,19 @@ namespace {
         ASSERT_EQ(
                 (std::hash<cnl::fraction<>>{}(cnl::fraction<>{1, 2})),
                 (std::hash<cnl::fraction<>>{}(cnl::fraction<>{12, 24})));
+    }
+
+    TEST(fraction, to_string)  // NOLINT
+    {
+        using namespace std::literals::string_literals;
+        ASSERT_EQ("5/7"s, cnl::to_string(cnl::fraction{cnl::int8{5}, cnl::uint8{7}}));
+    }
+
+    TEST(fraction, ostream)  // NOLINT
+    {
+        using namespace std::literals::string_literals;
+        std::stringstream s;
+        s << cnl::fraction{cnl::int8{5}, cnl::uint8{7}};
+        ASSERT_EQ("5/7"s, s.str());
     }
 }


### PR DESCRIPTION
- replaces naive operator<< which printed char-sized integers
  as chars, not numbers