### PR TITLE
Remove gh-pages submodule

### DIFF
--- a/.github/deploy
+++ b/.github/deploy
@@ -21,20 +21,29 @@ else
     exit 1
 fi
 
+# Clone CNL at gh-pages branch
+git clone \
+  --branch gh-pages \
+  --single-branch \
+  "https://johnmcfarlane:${GITHUB_TOKEN}@github.com/johnmcfarlane/cnl.git" \
+  htdocs
+
 # Generate documentation
+rm -rf htdocs/*
 "${PROJECT_DIR}/doc/generate"
 
 # Push revision of documentation
-pushd "${PROJECT_DIR}/doc/gh-pages"
+pushd htdocs
 git config --global user.email "github@john.mcfarlane.name"
 git config --global user.name "John McFarlane"
-git remote set-url origin "https://johnmcfarlane:${GITHUB_TOKEN}@github.com/johnmcfarlane/cnl.git"
 git reset origin/gh-pages
 git checkout gh-pages
 git add .
-if git commit -m"Documentation v${CNL_VERSION}"
+if git commit \
+  --amend \
+  --message="Documentation v${CNL_VERSION}"
 then
-  git push
+  git push --force
 fi
 popd
 

--- a/.github/deploy
+++ b/.github/deploy
@@ -17,7 +17,7 @@ then
     export CNL_VERSION="${BASH_REMATCH[1]}"
     echo "CNL version ${CNL_VERSION}"
 else
-    echo "Tag ${CNL_VERSION_TAG} not recognized as Semver version tag"
+    echo "Tag ${CNL_VERSION_TAG} not recognized as Semver version tag in the form refs/tags/v1.2.3"
     exit 1
 fi
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "doc/gh-pages"]
-	path = doc/gh-pages
-	url = https://github.com/johnmcfarlane/cnl.git
-	branch = gh-pages

--- a/doc/generate
+++ b/doc/generate
@@ -10,7 +10,7 @@ PROJECT_DIR=$(
 )
 
 # Modify Doxyfile settings with environment variables.
-export HTML_OUTPUT=${HTML_OUTPUT:-"${PROJECT_DIR}/doc/gh-pages"}
+export HTML_OUTPUT=${HTML_OUTPUT:-"$(pwd)/htdocs"}
 export CNL_VERSION=${CNL_VERSION:-"development"}
 export CNL_DIR="${PROJECT_DIR}"
 


### PR DESCRIPTION
In !715, there was a failed attempt to remove all of the bulk of the gh-pages branch by force-pushing back to its initial node. However, that retroactively breaks most/all commits in the main/v1.x branches back to their initial node because they all contain a submodule reference to some commit in gh-pages. So those cannot easily be deleted now.

The compromise is the remove all commits which do not yet feature in a doc/gh-pages submodule reference and change the script so it doesn't add fresh new Doxygen content, but instead replaces the previous head of gh-pages. The submodule reference is also removed as it serves no purpose other than to make the content of /doc slightly more confusing.