### PR TITLE
v1.x: Fix compilation of enable_if_t for scaled_integer/to_chars.h

### DIFF
--- a/include/cnl/_impl/scaled_integer/to_chars.h
+++ b/include/cnl/_impl/scaled_integer/to_chars.h
@@ -114,7 +114,7 @@ namespace cnl {
                 char* const first,
                 char* last,
                 scaled_integer<Rep, power<Exponent, Radix>> const& value)
-        -> enable_if_t<integer_digits<scaled_integer<Rep, power<Exponent, Radix>>>::value<4, char*>
+        -> enable_if_t<(integer_digits<scaled_integer<Rep, power<Exponent, Radix>>>::value<4), char*>
         {
             // zero-out all of the characters in the output string
             std::fill<char*>(first, last, '0');


### PR DESCRIPTION
Latest MSVC (16.8) gives big compile error explosion on this, without the added parenthesis it seems to be treating the < as part of the type/template rather than a less than.