### PR TITLE
Add missing input tag to set_tag<wrapper<...>>

### DIFF
--- a/include/cnl/_impl/wrapper/set_tag.h
+++ b/include/cnl/_impl/wrapper/set_tag.h
@@ -14,8 +14,9 @@
 
 /// compositional numeric library
 namespace cnl {
-    template<typename Rep, class OutTag>
-    struct set_tag<_impl::wrapper<Rep>, OutTag> : std::type_identity<_impl::wrapper<Rep, OutTag>> {
+    template<typename Rep, class Tag, class OutTag>
+    struct set_tag<_impl::wrapper<Rep, Tag>, OutTag>
+        : std::type_identity<_impl::wrapper<Rep, OutTag>> {
     };
 }
 


### PR DESCRIPTION
- would only have been working for wrapper<Rep, native_tag> previously