### PR TITLE
Fix to osx compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ Optional integration tests use Boost.Multiprecision and Boost.SIMD.
 2. Configure the project for development
 
    ```shell
-   cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROJECT_cnl_INCLUDE:FILEPATH="$(pwd)"/conan_paths.cmake ..
+   cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROJECT_cnl_INCLUDE:FILEPATH="$(pwd)"/conan_paths.cmake \ 
+   -DCMAKE_TOOLCHAIN_FILE:FILEPATH="$(pwd)"/../test/toolchain/<toolchain>.cmake ..
    ```
+   For the above select the toolchain appropriately from clang, clang-libc++, gcc, gcc-armv7 or msvc   
 
 3. Build tests:
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class CnlConan(ConanFile):
         "target": None,
         "test_pattern": None,
     }
-    generators = "cmake_find_package"
+    generators = "cmake_paths", "cmake_find_package"
     no_copy_source = True
     requires = "gtest/1.10.0", "benchmark/1.5.2"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,8 +37,11 @@ endif ()
 find_package(GTest)
 if (${GTest_FOUND})
     # workaround for github.com/conan-io/conan-center-index/issues/3222
-    set(CNL_GTEST_MAIN_TARGET GTest::Main CACHE STRING "alternative GTest target name")
-
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        set(CNL_GTEST_MAIN_TARGET GTest::gtest_main CACHE STRING "alternative GTest target name")
+    else()
+        set(CNL_GTEST_MAIN_TARGET GTest::Main CACHE STRING "alternative GTest target name")
+    endif()
     add_subdirectory(unit)
 else ()
     message(STATUS "Google Test is required to build unit tests.")

--- a/test/toolchain/clang-libc++.cmake
+++ b/test/toolchain/clang-libc++.cmake
@@ -13,7 +13,11 @@ set(INT128_ENABLED_FLAGS "-DCNL_USE_INT128=1")
 set(INT128_DISABLED_FLAGS "-DCNL_USE_INT128=0")
 
 set(SANITIZE_ENABLED_CXX_FLAGS "-fsanitize=address,undefined -fsanitize-trap=undefined -g -O0")
-set(SANITIZE_ENABLED_LINKER_FLAGS "-fsanitize=address,undefined -rtlib=compiler-rt -lgcc_s")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(SANITIZE_ENABLED_LINKER_FLAGS "-fsanitize=address,undefined -rtlib=compiler-rt")
+else()
+    set(SANITIZE_ENABLED_LINKER_FLAGS "-fsanitize=address,undefined -rtlib=compiler-rt -lgcc_s")
+endif()
 
 set(TEST_CXX_FLAGS "-Wconversion -Wno-sign-conversion -ftemplate-backtrace-limit=0")
 set(SAMPLE_CXX_FLAGS "-fpermissive -Wno-sign-compare -Wno-strict-overflow")


### PR DESCRIPTION
Fixes so that compilation and tests on osx work for gcc-10 with gcc toolchain and clang-11 with clang-libc++ toolchain. 