### PR TITLE
Add PlatformIO support

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,19 @@
+{
+    "name": "cnl",
+    "description": "C++ library of fixed-precision numeric classes which enhance integers to deliver safer, simpler, cheaper arithmetic types.",
+    "version": "1.1.6",
+    "license": "BSL-1.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/johnmcfarlane/cnl.git"
+    },
+    "build": {
+        "includeDir": "include",
+        "libArchive": false
+    },
+    "export": {
+        "include": [
+            "include/*"
+        ]
+    }
+}

--- a/library.json
+++ b/library.json
@@ -2,6 +2,10 @@
     "name": "cnl",
     "description": "C++ library of fixed-precision numeric classes which enhance integers to deliver safer, simpler, cheaper arithmetic types.",
     "version": "1.1.6",
+    "authors": {
+        "name": "John McFarlane",
+        "email": "cnl@john.mcfarlane.name"
+    },
     "license": "BSL-1.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
First, thanks for this very good library.

PlatformIO is a system for embedded development and CNL would be a great addition. library.json describes the package and its presence is useful because:
1. Fixes a weird behaviour within PlatformIO, when `includeDir` (`-I`) path is aimed at cnl/include/cnl which breaks the intended `#include "cnl/all.h"`. Documentation says that `includeDir = include` but this apparently doesn't apply when the manifest is missing. Probably some heuristics, looking for the "right" path...
2. Allows for publishing the library to https://platformio.org/lib using `lib_deps = cnl` in your project's .ini. This is not a strict requirement, the following works also: `lib_deps = https://github.com/ johnmcfarlane /cnl/archive/v1.x.zip`

This change will add a development burden with incrementing the "version" field upon releases... Is this an issue?

PS: We'd want this also for v2!

