### PR TITLE
Set cmake.verbose=False in conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -41,6 +41,7 @@ class CnlConan(ConanFile):
 
     def build(self):
         cmake = CMake(self, set_cmake_flags=True)
+        cmake.verbose = False
 
         if self.should_configure:
             self.configure_phase(cmake)


### PR DESCRIPTION
- This makes the default explicit.
- It's purely so I can remember where to flip the switch.