### PR TITLE
Disable flaky Clang-Tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,7 @@ Checks: >
   -modernize-avoid-c-arrays,
   -modernize-concat-nested-namespaces,
   -modernize-unary-static-assert,
+  -readability-avoid-const-params-in-decls,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'include/cnl'

--- a/include/cnl/_impl/scaled_integer/to_chars.h
+++ b/include/cnl/_impl/scaled_integer/to_chars.h
@@ -87,7 +87,7 @@ namespace cnl {
         template<typename Rep, int Exponent, int Radix>
         auto to_chars_fractional_specialized(
                 char* first,
-                char const* const last,  // NOLINT(readability-avoid-const-params-in-decls)
+                char const* const last,
                 scaled_integer<Rep, power<Exponent, Radix>> value) requires(integer_digits<scaled_integer<Rep, power<Exponent, Radix>>> >= 4)
         {
             do {
@@ -114,7 +114,7 @@ namespace cnl {
         // case where value doesn't have enough integer digits to hold range, [0..10)
         template<typename Rep, int Exponent, int Radix>
         auto to_chars_fractional_specialized(
-                char* const first,  // NOLINT(readability-avoid-const-params-in-decls)
+                char* const first,
                 char* last,
                 scaled_integer<Rep, power<Exponent, Radix>> const& value) requires(integer_digits<scaled_integer<Rep, power<Exponent, Radix>>> < 4)
         {

--- a/include/cnl/_impl/to_chars.h
+++ b/include/cnl/_impl/to_chars.h
@@ -65,8 +65,8 @@ namespace cnl {
 
         template<integer Integer>
         auto to_chars_positive(
-                char* const first,  // NOLINT(readability-avoid-const-params-in-decls)
-                char* const last,  // NOLINT(readability-avoid-const-params-in-decls)
+                char* const first,
+                char* const last,
                 Integer const& value) noexcept
         {
             auto const natural_last = to_chars_natural(first, last, value);
@@ -102,8 +102,8 @@ namespace cnl {
     // partial implementation of std::to_chars overloaded on cnl::duplex_integer
     template<integer Integer>
     [[nodiscard]] constexpr auto to_chars(
-            char* const first,  // NOLINT(readability-avoid-const-params-in-decls)
-            char* const last,  // NOLINT(readability-avoid-const-params-in-decls,readability-non-const-parameter)
+            char* const first,
+            char* const last,  // NOLINT(readability-non-const-parameter)
             Integer const& value)
     {
         if (!value) {


### PR DESCRIPTION
- readability-avoid-const-params-in-decls complains about 'declarations'
  which are patently definitions