### PR TITLE
Fixes to _impl::unreachable & CNL_ASSUME

### DIFF
--- a/include/cnl/_impl/cnl_assert.h
+++ b/include/cnl/_impl/cnl_assert.h
@@ -10,6 +10,7 @@
 #include "config.h"
 #include "likely.h"
 #include "terminate.h"
+#include "unreachable.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // CNL_ASSUME - hints that a condition *must* be true
@@ -18,9 +19,9 @@
 #define CNL_ASSUME(cond) __assume(cond)
 #elif defined(__GNUC__)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define CNL_ASSUME(cond) ((cond) ? static_cast<void>(0) : __builtin_unreachable())
+#define CNL_ASSUME(cond) ((cond) ? static_cast<void>(0) : cnl::_impl::unreachable("incorrect assumption"))
 #else
-#define CNL_ASSUME(cond) static_cast<void>((cond) ? 0 : 0)
+#define CNL_ASSUME(cond) static_cast<void>(sizeof(cond) ? 0 : 0)
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/cnl/_impl/unreachable.h
+++ b/include/cnl/_impl/unreachable.h
@@ -13,7 +13,7 @@
 namespace cnl {
     namespace _impl {
 #if defined(CNL_UNREACHABLE_UB_ENABLED)
-        template<class Result>
+        template<class Result = void>
         constexpr auto unreachable(char const* /*message*/) noexcept -> Result
         {
 #if defined(_MSC_VER)
@@ -29,7 +29,7 @@ namespace cnl {
 #endif
         }
 #else
-        template<class Result>
+        template<class Result = void>
         constexpr Result unreachable(char const* message) noexcept
         {
             return terminate<Result>(message);


### PR DESCRIPTION
- CNL_ASSUME tied to _impl::unreachable
- condition of CNL_ASSUME no evaluated in default case (non-GCC/Clang/MSVC)
- unreachable("message") invocation allowed