### PR TITLE
Fix support for streaming decimal scaled_integer

### DIFF
--- a/include/cnl/_impl/scaled_integer/to_chars.h
+++ b/include/cnl/_impl/scaled_integer/to_chars.h
@@ -37,16 +37,56 @@
 /// compositional numeric library
 namespace cnl {
     namespace _impl {
-        template<typename Rep, int Exponent>
-        struct max_to_chars_chars<scaled_integer<Rep, power<Exponent>>> {
+        constexpr auto num_digits_from_binary(int num_digits, int radix)
+        {
+            switch (radix) {
+            case 2:
+                return num_digits;
+            case 8:
+                return (num_digits + 2) / 3;
+            case 10:
+                return (num_digits * 1000 + 3322) / 3321;
+            case 16:
+                return (num_digits + 3) / 4;
+            default: {
+                auto const binary_digits_per_digit{used_digits(radix - 1)};
+                return (num_digits + binary_digits_per_digit - 1) / binary_digits_per_digit;
+            }
+            }
+        }
+
+        constexpr auto num_digits_to_binary(int num_digits, int radix)
+        {
+            switch (radix) {
+            case 2:
+                return num_digits;
+            case 8:
+                return num_digits * 3;
+            case 10:
+                return (num_digits * 3322 + 678) / 1000;
+            case 16:
+                return num_digits * 4;
+            default:
+                return num_digits * used_digits(radix - 1);
+            }
+        }
+
+        template<typename Rep, int Exponent, int Radix>
+        struct max_to_chars_chars<scaled_integer<Rep, power<Exponent, Radix>>> {
         private:
-            using _scalar = cnl::scaled_integer<Rep, power<Exponent>>;
+            using _scalar = cnl::scaled_integer<Rep, power<Exponent, Radix>>;
+
+            // This number is a little pessemistic in the case that Radix != 2.
             static constexpr auto _fractional_digits =
-                    cnl::_impl::fractional_digits<_scalar>;
+                    std::max(cnl::_impl::fractional_digits<_scalar>, 0);
 
             static constexpr auto _sign_chars = static_cast<int>(cnl::numbers::signedness_v<_scalar>);
-            static constexpr auto _integer_chars =
-                    ((cnl::_impl::integer_digits<_scalar> + 2) / 3);
+            static constexpr auto _num_significant_integer_bits{cnl::digits_v<_scalar> - _fractional_digits};
+            static constexpr auto _num_trailing_integer_bits{
+                    num_digits_to_binary(std::max(0, Exponent), Radix)};
+            static constexpr auto _num_integer_bits{
+                    _num_significant_integer_bits + _num_trailing_integer_bits};
+            static constexpr auto _integer_chars = num_digits_from_binary(_num_integer_bits, 10);
             static constexpr auto _radix_chars = static_cast<int>(_fractional_digits > 0);
             static constexpr auto _fractional_chars = std::max(0, _fractional_digits);
 

--- a/include/cnl/_impl/scaled_integer/to_string.h
+++ b/include/cnl/_impl/scaled_integer/to_string.h
@@ -7,6 +7,8 @@
 #if !defined(CNL_IMPL_SCALED_INTEGER_TO_STRING_H)
 #define CNL_IMPL_SCALED_INTEGER_TO_STRING_H
 
+#include "../../integer.h"
+#include "../scaled/is_scaled_tag.h"
 #include "definition.h"
 #include "to_chars.h"
 
@@ -16,8 +18,8 @@
 namespace cnl {
     using std::to_string;
 
-    template<typename Rep, int Exponent>
-    auto to_string(cnl::scaled_integer<Rep, power<Exponent>> const& value)
+    template<integer Rep, scaled_tag Scale>
+    auto to_string(cnl::scaled_integer<Rep, Scale> const& value)
     {
         auto const [chars, length] = to_chars_static(value);
         return std::string{chars.data(), unsigned(length)};

--- a/include/cnl/elastic_scaled_integer.h
+++ b/include/cnl/elastic_scaled_integer.h
@@ -116,7 +116,7 @@ namespace cnl {
         [[nodiscard]] constexpr auto make_from_udl()
         {
             constexpr auto descaled{
-                    descale<intmax, UdlRadix, true>(
+                    descale<decltype(ParsedSignificand), UdlRadix, true>(
                             ParsedSignificand,
                             power<ParsedExponent, ParsedRadix>{})};
             constexpr auto rep{make_elastic_integer(constant<descaled.significand>{})};

--- a/test/unit/scaled_integer/elastic/elastic_scaled_integer.cpp
+++ b/test/unit/scaled_integer/elastic/elastic_scaled_integer.cpp
@@ -346,6 +346,9 @@ namespace test_literal_decimal_cnl2 {
 }
 
 namespace test_literal_decimal_cnl {
+    static_assert(identical(.001_cnl, elastic_scaled_integer<1, cnl::power<-3, 10>>{0.001}));
+    static_assert(identical(-0.001_cnl, elastic_scaled_integer<1, cnl::power<-3, 10>>{-0.001}));
+
     static_assert(identical(00.1_cnl, elastic_scaled_integer<1, cnl::power<-1, 10>>{00.1}));
     static_assert(identical(-.1_cnl, elastic_scaled_integer<1, cnl::power<-1, 10>>{-.1}));
 
@@ -623,6 +626,36 @@ TEST(elastic_scaled_integer, issue_88)  // NOLINT
     EXPECT_EQ(static_cast<float>(c), 1.0F);
     fix_t d = c + a * b;
     EXPECT_EQ(static_cast<float>(d), 3.0F);
+}
+
+TEST(elastic_scaled_integer, to_string_thousand)  // NOLINT
+{
+    auto const n{1000_cnl};
+    static_assert(5 == cnl::_impl::max_to_chars_chars<std::remove_cvref_t<decltype(n)>>::value);
+
+    auto const expected{"1000"};
+    auto const actual{cnl::to_string(1000_cnl)};
+    ASSERT_EQ(expected, actual);
+}
+
+TEST(elastic_scaled_integer, to_string_thousandth)  // NOLINT
+{
+    auto const n{.001_cnl};
+    static_assert(5 == cnl::_impl::max_to_chars_chars<std::remove_cvref_t<decltype(n)>>::value);
+
+    auto const expected{".001"};
+    auto const actual{cnl::to_string(n)};
+    ASSERT_EQ(expected, actual);
+}
+
+TEST(elastic_scaled_integer, to_string_quite_wide)  // NOLINT
+{
+    auto const n{-12345.67890_cnl};
+    static_assert(13 == cnl::_impl::max_to_chars_chars<std::remove_cvref_t<decltype(n)>>::value);
+
+    auto const expected{"-12345.6789"};
+    auto const actual{cnl::to_string(n)};
+    ASSERT_EQ(expected, actual);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/unit/scaled_integer/to_chars.h
+++ b/test/unit/scaled_integer/to_chars.h
@@ -28,7 +28,7 @@ namespace {
                 7 == cnl::_impl::max_to_chars_chars<scaled_integer<int8, cnl::power<-3>>>::value,
                 "cnl::_impl::max_to_chars_chars");  // -15.875
         static_assert(
-                6 == cnl::_impl::max_to_chars_chars<scaled_integer<uint16, cnl::power<>>>::value,
+                5 == cnl::_impl::max_to_chars_chars<scaled_integer<uint16, cnl::power<>>>::value,
                 "cnl::_impl::max_to_chars_chars");  // 65536
         static_assert(
                 41
@@ -36,7 +36,7 @@ namespace {
                                 cnl::elastic_integer<41>, cnl::power<-38>>>::value,
                 "cnl::_impl::max_to_chars_chars");
         static_assert(
-                45
+                44
                         == cnl::_impl::max_to_chars_chars<
                                 cnl::scaled_integer<int64, cnl::power<-32>>>::value,
                 "cnl::_impl::max_to_chars_chars");  // −2147483647.99999999976716935634613037109375
@@ -226,6 +226,11 @@ namespace {
         TEST(to_chars, scaled_integer_decimal_no_fractional)  // NOLINT
         {
             test<7>("-517523", cnl::scaled_integer<int, cnl::power<0, 10>>(-517523));
+        }
+
+        TEST(to_chars, scaled_integer_decimal_thousandth)  // NOLINT
+        {
+            test<7>(".001", cnl::scaled_integer<int, cnl::power<-3, 10>>(1) / 1000);
         }
 
         TEST(to_chars, scaled_integer_binary_negative_highly_fractional)  // NOLINT


### PR DESCRIPTION
- to_string of scaled_integer now takes non-binary radixes
  - mainly, this means calculating the correct maximum width of a number
    once it's converted to decimal
    - generalising this to all bases is not fun
- added test of
  - UDLs involving thousandths
  - some mildly ugly-ass UDLs being converted back into decimal in strings