### PR TITLE
Guard tests that often fail to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,7 @@ Optional integration tests use Boost.Multiprecision and Boost.SIMD.
    conan profile new --detect --force default
    conan profile update settings.compiler.libcxx=libstdc++11 default  # GCC only
    conan profile update settings.compiler.cppstd=20 default
-   conan install \
-     --build=missing \
-     --env CONAN_CMAKE_TOOLCHAIN_FILE="/full/path/to/cnl/test/toolchain/gcc.cmake" \
-     --options test=unit \
-     ..
+   conan install --build=missing --options test=unit ..
    ```
 
    ... and then configure, build and run unit tests:

--- a/test/toolchain/clang-libc++.cmake
+++ b/test/toolchain/clang-libc++.cmake
@@ -1,6 +1,6 @@
 set(
     MISC_FLAGS
-    "-Werror -Wall -Wextra -Wpedantic -Wshadow -Wundef -ftemplate-backtrace-limit=0 -fconstexpr-backtrace-limit=0 -fconstexpr-steps=1000000000 -fdiagnostics-color=always -stdlib=libc++"
+    "-DCNL_IMPL_ONEROUS_EVALUATION -Werror -Wall -Wextra -Wpedantic -Wshadow -Wundef -ftemplate-backtrace-limit=0 -fconstexpr-backtrace-limit=0 -fconstexpr-steps=1000000000 -fdiagnostics-color=always -stdlib=libc++"
 )
 
 set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")

--- a/test/toolchain/clang.cmake
+++ b/test/toolchain/clang.cmake
@@ -1,6 +1,6 @@
 set(
     MISC_FLAGS
-    "-Werror -Wall -Wextra -Wpedantic -Wshadow -Wundef -ftemplate-backtrace-limit=0 -fconstexpr-backtrace-limit=0 -fconstexpr-steps=1000000000 -fdiagnostics-color=always"
+    "-DCNL_IMPL_ONEROUS_EVALUATION -Werror -Wall -Wextra -Wpedantic -Wshadow -Wundef -ftemplate-backtrace-limit=0 -fconstexpr-backtrace-limit=0 -fconstexpr-steps=1000000000 -fdiagnostics-color=always"
 )
 
 set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")

--- a/test/toolchain/gcc-armv7.cmake
+++ b/test/toolchain/gcc-armv7.cmake
@@ -1,6 +1,6 @@
 set(
     MISC_FLAGS
-    "-Werror -Wall -Wextra -Wpedantic -Wshadow -Wundef -fconcepts -fconstexpr-ops-limit=1000000000 -fdiagnostics-color=always -ftemplate-backtrace-limit=0 -pthread -Wno-psabi -march=armv7-a"
+    "-DCNL_IMPL_ONEROUS_EVALUATION -Werror -Wall -Wextra -Wpedantic -Wshadow -Wundef -fconcepts -fconstexpr-ops-limit=1000000000 -fdiagnostics-color=always -ftemplate-backtrace-limit=0 -pthread -Wno-psabi -march=armv7-a"
 )
 
 set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")

--- a/test/toolchain/gcc.cmake
+++ b/test/toolchain/gcc.cmake
@@ -1,6 +1,6 @@
 set(
     MISC_FLAGS
-    "-Werror -Wall -Wextra -Wno-psabi -Wpedantic -Wshadow -Wundef -fconcepts -fconstexpr-ops-limit=1000000000 -fdiagnostics-color=always -ftemplate-backtrace-limit=0 -pthread"
+    "-DCNL_IMPL_ONEROUS_EVALUATION -Werror -Wall -Wextra -Wno-psabi -Wpedantic -Wshadow -Wundef -fconcepts -fconstexpr-ops-limit=1000000000 -fdiagnostics-color=always -ftemplate-backtrace-limit=0 -pthread"
 )
 
 set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")

--- a/test/unit/_impl/wide_integer/generic.cpp
+++ b/test/unit/_impl/wide_integer/generic.cpp
@@ -70,7 +70,6 @@ namespace {
                 "cnl::wide_integer minus");
 
 #if !defined(_MSC_VER)
-        // requires elevated value of -fconstexpr-steps
         static_assert(
                 identical(
                         cnl::wide_integer<500, int>{-17292375928362489LL},

--- a/test/unit/_impl/wide_integer/literals.cpp
+++ b/test/unit/_impl/wide_integer/literals.cpp
@@ -43,7 +43,6 @@ namespace {
         static_assert(identical(cnl::wide_integer<29>{123456789}, 123456789_wide));
 
 #if defined(__clang__) || defined(CNL_INT128_ENABLED)
-        // requires that constexpr-steps is set very high
         static_assert(
                 identical(
                         cnl::wide_integer<182>{1} << 180,

--- a/test/unit/static_integer/operators.cpp
+++ b/test/unit/static_integer/operators.cpp
@@ -79,6 +79,8 @@ namespace {
     namespace test_divide {
         using namespace cnl::literals;
 
+// can only be compiled with constant evaluation limits raised
+#if defined(CNL_IMPL_ONEROUS_EVALUATION)
         static_assert(
                 identical(
                         cnl::static_integer<225>(
@@ -86,6 +88,7 @@ namespace {
                         cnl::make_static_integer(
                                 10000000000000000000000000000000000000000000000000000000000000000000_wide)
                                 / 3));
+#endif
 
 #if defined(__clang__)
         static_assert(

--- a/test/unit/static_integer/shift_left.cpp
+++ b/test/unit/static_integer/shift_left.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+// can only be compiled with constant evaluation limits raised
+#if defined(CNL_IMPL_ONEROUS_EVALUATION)
 #if defined(__SIZEOF_INT128__)
 TEST(static_integer, shift_left)  // NOLINT
 {
@@ -18,4 +20,5 @@ TEST(static_integer, shift_left)  // NOLINT
     auto actual = cnl::static_integer<260>{1} << 257;
     ASSERT_EQ(expected, actual);
 }
+#endif
 #endif


### PR DESCRIPTION
- require much compile-time evaluation