### PR TITLE
Define `LIBCXX_DEBUG` for GCC toolchain

### DIFF
--- a/test/toolchain/gcc.cmake
+++ b/test/toolchain/gcc.cmake
@@ -1,6 +1,6 @@
 set(
     MISC_FLAGS
-    "-DCNL_IMPL_ONEROUS_EVALUATION -Werror -Wall -Wextra -Wno-psabi -Wpedantic -Wshadow -Wundef -fconcepts -fconstexpr-ops-limit=1000000000 -fdiagnostics-color=always -ftemplate-backtrace-limit=0 -pthread"
+    "-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -DCNL_IMPL_ONEROUS_EVALUATION -Werror -Wall -Wextra -Wno-psabi -Wpedantic -Wshadow -Wundef -fconcepts -fconstexpr-ops-limit=1000000000 -fdiagnostics-color=always -ftemplate-backtrace-limit=0 -pthread"
 )
 
 set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")


### PR DESCRIPTION
- also _GLIBCXX_DEBUG_PEDANTIC
- enables run-time checking of some libstdc++ contracts