### PR TITLE
Remove inappropriate/superfluous instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,6 @@ Tested:
 
 ## Instructions
 
-### Download
-
-The library is [hosted](https://github.com/johnmcfarlane/cnl) on GitHub:
-
-```shell
-git clone https://github.com/johnmcfarlane/cnl.git
-cd cnl
-```
-
 ### Build
 
 CMake scripts are provided.


### PR DESCRIPTION
- How to clone is a step that gets your to the README, not a step you take
  after.