### PR TITLE
Replace use of std::terminate with std::abort

### DIFF
--- a/include/cnl/_impl/abort.h
+++ b/include/cnl/_impl/abort.h
@@ -4,24 +4,24 @@
 //    (See accompanying file ../LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(CNL_TERMINATE_H)
-#define CNL_TERMINATE_H
+#if !defined(CNL_ABORT_H)
+#define CNL_ABORT_H
 
 #include "config.h"
 
 #include <cstdio>
-#include <exception>
+#include <cstdlib>
 
 namespace cnl {
     namespace _impl {
         template<class Result>
-        [[noreturn]] constexpr auto terminate(char const* message) noexcept -> Result
+        [[noreturn]] constexpr auto abort(char const* message) noexcept -> Result
         {
             std::fputs(message, stderr);
             std::fputc('\n', stderr);
-            std::terminate();
+            std::abort();
         }
     }
 }
 
-#endif  // CNL_TERMINATE_H
+#endif  // CNL_ABORT_H

--- a/include/cnl/_impl/cnl_assert.h
+++ b/include/cnl/_impl/cnl_assert.h
@@ -7,9 +7,9 @@
 #if !defined(CNL_IMPL_CNL_ASSERT_H)
 #define CNL_IMPL_CNL_ASSERT_H
 
+#include "abort.h"
 #include "config.h"
 #include "likely.h"
-#include "terminate.h"
 #include "unreachable.h"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -36,7 +36,7 @@
 #include <exception>
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CNL_ASSERT(CONDITION) \
-    (CNL_LIKELY(CONDITION) ? static_cast<void>(0) : cnl::_impl::terminate<void>(#CONDITION))
+    (CNL_LIKELY(CONDITION) ? static_cast<void>(0) : cnl::_impl::abort<void>(#CONDITION))
 #else
 #error internal library error
 #endif

--- a/include/cnl/_impl/overflow/saturated.h
+++ b/include/cnl/_impl/overflow/saturated.h
@@ -8,7 +8,6 @@
 #define CNL_IMPL_OVERFLOW_SATURATED_H
 
 #include "../polarity.h"
-#include "../terminate.h"
 #include "is_overflow_tag.h"
 #include "is_tag.h"
 #include "overflow_operator.h"

--- a/include/cnl/_impl/overflow/trapping.h
+++ b/include/cnl/_impl/overflow/trapping.h
@@ -7,8 +7,8 @@
 #if !defined(CNL_IMPL_OVERFLOW_TRAPPING_H)
 #define CNL_IMPL_OVERFLOW_TRAPPING_H
 
+#include "../abort.h"
 #include "../polarity.h"
-#include "../terminate.h"
 #include "is_overflow_tag.h"
 #include "is_tag.h"
 #include "overflow_operator.h"
@@ -17,7 +17,7 @@
 namespace cnl {
     /// \brief tag to specify trap-on-overflow behavior in arithemtic operations
     ///
-    /// Arithmetic operations using this tag call \ref std::terminate when the result exceeds the
+    /// Arithmetic operations using this tag call \ref std::abort when the result exceeds the
     /// range of the result type.
     ///
     /// \headerfile cnl/overflow.h
@@ -38,14 +38,14 @@ namespace cnl {
             template<typename Destination, typename Source>
             [[nodiscard]] constexpr auto operator()(Source const&) const
             {
-                return terminate<Destination>("positive overflow");
+                return abort<Destination>("positive overflow");
             }
 
             template<class... Operands>
             [[nodiscard]] constexpr auto operator()(
                     Operands const&...) const
             {
-                return terminate<op_result<Operator, Operands...>>("positive overflow");
+                return abort<op_result<Operator, Operands...>>("positive overflow");
             }
         };
 
@@ -54,14 +54,14 @@ namespace cnl {
             template<typename Destination, typename Source>
             [[nodiscard]] constexpr auto operator()(Source const&) const
             {
-                return terminate<Destination>("negative overflow");
+                return abort<Destination>("negative overflow");
             }
 
             template<class... Operands>
             [[nodiscard]] constexpr auto operator()(
                     Operands const&...) const
             {
-                return terminate<op_result<Operator, Operands...>>("negative overflow");
+                return abort<op_result<Operator, Operands...>>("negative overflow");
             }
         };
     }

--- a/include/cnl/_impl/throw_exception.h
+++ b/include/cnl/_impl/throw_exception.h
@@ -7,8 +7,8 @@
 #if !defined(CNL_THROW_EXCEPTION_H)
 #define CNL_THROW_EXCEPTION_H
 
+#include "abort.h"
 #include "config.h"
-#include "terminate.h"
 
 #include <type_traits>
 
@@ -20,7 +20,7 @@ namespace cnl {
 #if defined(CNL_EXCEPTIONS_ENABLED)
             return true ? throw Exception(message) : Result{};
 #else
-            return terminate<Result>(message);
+            return abort<Result>(message);
 #endif
         }
     }

--- a/include/cnl/_impl/unreachable.h
+++ b/include/cnl/_impl/unreachable.h
@@ -7,8 +7,8 @@
 #if !defined(CNL_IMPL_UNREACHABLE_H)
 #define CNL_IMPL_UNREACHABLE_H
 
+#include "abort.h"
 #include "config.h"
-#include "terminate.h"
 
 namespace cnl {
     namespace _impl {
@@ -27,7 +27,7 @@ namespace cnl {
         template<class Result = void>
         constexpr Result unreachable(char const* message) noexcept
         {
-            return terminate<Result>(message);
+            return abort<Result>(message);
         }
 #endif
     }

--- a/test/unit/boost.throw_exception.h
+++ b/test/unit/boost.throw_exception.h
@@ -15,8 +15,8 @@
 namespace boost {
 #if defined(BOOST_NO_EXCEPTIONS)
     inline void throw_exception(std::exception const&)
-    {  // NOLINT(readability-redundant-declaration)
-        std::terminate();
+    {
+        std::abort();
     }
 #endif
 }


### PR DESCRIPTION
- in line with how GCC disables exception throwing
  https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_exceptions.html
- in line with how best practices on handling contract violation
  http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2388r3.html#rat.end