### PR TITLE
CI job shuffle

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >
   *,
+  -altera-*,
   -cert-err58-cpp,
   -clang-analyzer-osx.*,
   -cppcoreguidelines-avoid-magic-numbers,
@@ -16,11 +17,12 @@ Checks: >
   -llvm-qualified-auto,
   -llvmlibc-*,
   -modernize-use-trailing-return-type,
+  -readability-identifier-length,
   -readability-implicit-bool-conversion,
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
-  -altera-struct-pack-align,
+  -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
@@ -158,14 +160,16 @@ CheckOptions:
     value:           lower_case
   - key:             readability-identifier-naming.TypedefCase
     value:           lower_case
-  - key:             readability-identifier-naming.TypeTemplateParameterCase
-    value:           CamelCase
+  # https://bugs.llvm.org/show_bug.cgi?id=46752
+  # - key:             readability-identifier-naming.TypeTemplateParameterCase
+  #   value:           CamelCase
   - key:             readability-identifier-naming.ValueTemplateParameterCase
     value:           CamelCase
   - key:             readability-identifier-naming.TemplateTemplateParameterCase
     value:           CamelCase
-  - key:             readability-identifier-naming.TemplateParameterCase
-    value:           CamelCase
+  # https://bugs.llvm.org/show_bug.cgi?id=46752
+  # - key:             readability-identifier-naming.TemplateParameterCase
+  #   value:           CamelCase
   - key:             readability-identifier-naming.TypeAliasCase
     value:           lower_case
   - key:             readability-identifier-naming.MacroDefinitionCase

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -57,7 +57,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3", "8.4",
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1", "10.2", "10.3",
-                  "11", "11.1"]
+                  "11", "11.1",
+                  "12"]
         libcxx: [libstdc++, libstdc++11]
         threads: [None, posix, win32]  # Windows MinGW
         exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
@@ -82,7 +83,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10", "11", "12", "13"]
+                  "8", "9", "10", "11", "12", "13", "14"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [None, MD, MT, MTd, MDd]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,7 +378,7 @@ jobs:
   # Test shell scripts
   clang-format:
     runs-on: ubuntu-20.04
-    container: johnmcfarlane/cnl_ci:clang-11
+    container: johnmcfarlane/cnl_ci:clang-13
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
   posix-conan-test:
     strategy:
       matrix:
-        name: [clang-12, clang-12-sanitize, clang-11, clang-10, gcc-10, osx-clang, osx-gcc-11, gcc-10-armv7]
+        name: [clang-head-analyse, gcc-head, clang-13, clang-12, clang-11, clang-10, gcc-11, gcc-10, osx-clang-13, osx-gcc-11, gcc-10-armv7]
         include:
-          # Clang-12 (w. Clang-Tidy)
-          - name: clang-12
+          # Clang HEAD (w. Clang-Tidy, sanitizers)
+          - name: clang-head-analyse
             compiler: clang
-            version: "12"
+            version: "14"
             os: linux
             arch: x86_64
             build-type: Release
@@ -27,16 +27,36 @@ jobs:
             generator: "Ninja"
             int128: "True"
             iostreams: "True"
-            linux-container: johnmcfarlane/cnl_ci:clang-12-libcpp
+            linux-container: johnmcfarlane/cnl_ci:clang-head
             os-version: ubuntu-20.04
-            sanitize: "False"
+            sanitize: "True"
             stdlib: libc++
             toolchain: clang-libc++.cmake
 
-          # Clang-12 (w. ASan + UBSan)
-          - name: clang-12-sanitize
-            compiler: clang
+          # GCC HEAD
+          - name: gcc-head
+            compiler: gcc
             version: "12"
+            os: linux
+            arch: x86_64
+            build-type: Release
+            cc: gcc
+            clang_tidy: "False"
+            cxx: g++
+            exceptions: "True"
+            generator: "Ninja"
+            int128: "True"
+            iostreams: "True"
+            linux-container: johnmcfarlane/cnl_ci:gcc-head
+            os-version: ubuntu-20.04
+            sanitize: "True"
+            stdlib: libstdc++11
+            toolchain: gcc.cmake
+
+          # Clang-13
+          - name: clang-13
+            compiler: clang
+            version: "13"
             os: linux
             arch: x86_64
             build-type: Release
@@ -47,11 +67,31 @@ jobs:
             generator: "Ninja"
             int128: "False"
             iostreams: "True"
-            linux-container: johnmcfarlane/cnl_ci:clang-12-libcpp
+            linux-container: johnmcfarlane/cnl_ci:clang-13-libstdcpp
             os-version: ubuntu-20.04
             sanitize: "True"
-            stdlib: libc++
-            toolchain: clang-libc++.cmake
+            stdlib: libstdc++11
+            toolchain: clang.cmake
+
+          # Clang-12 (Contrary)
+          - name: clang-12
+            compiler: clang
+            version: "12"
+            os: linux
+            arch: x86_64
+            build-type: Debug
+            cc: clang
+            clang_tidy: "False"
+            cxx: clang++
+            exceptions: "True"
+            generator: "Unix Makefiles"
+            int128: "False"
+            iostreams: "False"
+            linux-container: johnmcfarlane/cnl_ci:clang-12-libstdcpp
+            os-version: ubuntu-20.04
+            sanitize: "False"
+            stdlib: libstdc++11
+            toolchain: clang.cmake
 
           # Clang-11
           - name: clang-11
@@ -85,13 +125,33 @@ jobs:
             cxx: clang++
             exceptions: "True"
             generator: "Ninja"
-            int128: "True"
+            int128: "False"
             iostreams: "True"
             linux-container: johnmcfarlane/cnl_ci:clang-10-libcpp
             os-version: ubuntu-20.04
-            sanitize: "False"
+            sanitize: "True"
             stdlib: libc++
             toolchain: clang-libc++.cmake
+
+          # GCC-11
+          - name: gcc-11
+            compiler: gcc
+            version: "11"
+            os: linux
+            arch: x86_64
+            build-type: Release
+            cc: gcc-11
+            clang_tidy: "False"
+            cxx: g++-11
+            exceptions: "True"
+            generator: "Ninja"
+            int128: "True"
+            iostreams: "True"
+            linux-container: johnmcfarlane/cnl_ci:gcc-11
+            os-version: ubuntu-20.04
+            sanitize: "True"
+            stdlib: libstdc++11
+            toolchain: gcc.cmake
 
           # GCC-10 (Contrary)
           - name: gcc-10
@@ -109,26 +169,26 @@ jobs:
             iostreams: "False"
             linux-container: johnmcfarlane/cnl_ci:gcc-10
             os-version: ubuntu-20.04
-            sanitize: "True"
+            sanitize: "False"
             stdlib: libstdc++11
             toolchain: gcc.cmake
 
           # OS X Clang (latest)
-          - name: osx-clang
+          - name: osx-clang-13
             os: osx
             compiler: clang
             version: "13"
             arch: x86_64
-            build-type: Debug
+            build-type: Release
             cc: "/usr/local/opt/llvm/bin/clang"
             clang_tidy: "False"
             cxx: "/usr/local/opt/llvm/bin/clang++"
-            exceptions: "False"
-            generator: "Unix Makefiles"
+            exceptions: "True"
+            generator: "Ninja"
             int128: "True"
             iostreams: "True"
             os-version: macos-10.15
-            sanitize: "False"
+            sanitize: "True"
             stdlib: libc++
             toolchain: clang-libc++.cmake
 
@@ -147,12 +207,12 @@ jobs:
             int128: "True"
             iostreams: "True"
             os-version: macos-10.15
-            sanitize: "False"
+            sanitize: "True"
             stdlib: libstdc++11
             toolchain: gcc.cmake
 
           # GCC-10 (for ARMv7)
-          - name: armv7
+          - name: gcc-10-armv7
             arch: armv7
             compiler: gcc
             version: "10"
@@ -167,7 +227,7 @@ jobs:
             iostreams: "True"
             linux-container: johnmcfarlane/cnl_ci:gcc-10-arm
             os-version: ubuntu-20.04
-            sanitize: "False"
+            sanitize: "True"
             stdlib: libstdc++11
             toolchain: gcc-armv7.cmake
 
@@ -307,17 +367,17 @@ jobs:
   linux-cmake-test:
     strategy:
       matrix:
-        compiler: [clang-head, gcc-head]
+        compiler: [clang-13-libcpp, gcc-11]
 
         include:
-          - compiler: clang-head
+          - compiler: clang-13-libcpp
             cxx_extensions: "ON"
             toolchain: clang.cmake
-            container: johnmcfarlane/cnl_ci:clang-head-libstdcpp
-          - compiler: gcc-head
+            container: johnmcfarlane/cnl_ci:clang-13-libcpp
+          - compiler: gcc-11
             cxx_extensions: "OFF"
             toolchain: gcc.cmake
-            container: johnmcfarlane/cnl_ci:gcc-head
+            container: johnmcfarlane/cnl_ci:gcc-11
 
     container: ${{matrix.container}}
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,27 +11,8 @@ jobs:
   posix-conan-test:
     strategy:
       matrix:
-        name: [osx-clang, clang-12, osx-gcc-11, gcc-10, clang-10, clang-11, clang-12-sanitize, armv7]
+        name: [clang-12, clang-12-sanitize, clang-11, clang-10, gcc-10, osx-clang, osx-gcc-11, gcc-10-armv7]
         include:
-          # OS X Clang (latest)
-          - name: osx-clang
-            os: osx
-            compiler: clang
-            version: "13"
-            arch: x86_64
-            build-type: Debug
-            cc: "/usr/local/opt/llvm/bin/clang"
-            clang_tidy: "False"
-            cxx: "/usr/local/opt/llvm/bin/clang++"
-            exceptions: "False"
-            generator: "Unix Makefiles"
-            int128: "True"
-            iostreams: "True"
-            os-version: macos-10.15
-            sanitize: "False"
-            stdlib: libc++
-            toolchain: clang-libc++.cmake
-
           # Clang-12 (w. Clang-Tidy)
           - name: clang-12
             compiler: clang
@@ -47,85 +28,6 @@ jobs:
             int128: "True"
             iostreams: "True"
             linux-container: johnmcfarlane/cnl_ci:clang-12-libcpp
-            os-version: ubuntu-20.04
-            sanitize: "False"
-            stdlib: libc++
-            toolchain: clang-libc++.cmake
-
-          # OS X GCC-11
-          - name: osx-gcc-11
-            os: osx
-            compiler: gcc
-            version: "11"
-            arch: x86_64
-            build-type: Release
-            cc: gcc-11
-            clang_tidy: "False"
-            cxx: g++-11
-            exceptions: "True"
-            generator: "Ninja"
-            int128: "True"
-            iostreams: "True"
-            os-version: macos-10.15
-            sanitize: "False"
-            stdlib: libstdc++11
-            toolchain: gcc.cmake
-
-          # GCC-10 (Contrary)
-          - name: gcc-10
-            compiler: gcc
-            version: "10"
-            os: linux
-            arch: x86_64
-            build-type: Debug
-            cc: gcc-10
-            clang_tidy: "False"
-            cxx: g++-10
-            exceptions: "False"
-            generator: "Unix Makefiles"
-            int128: "False"
-            iostreams: "False"
-            linux-container: johnmcfarlane/cnl_ci:gcc-10
-            os-version: ubuntu-20.04
-            sanitize: "True"
-            stdlib: libstdc++11
-            toolchain: gcc.cmake
-
-          # Clang-10
-          - name: clang-10
-            compiler: clang
-            version: "10"
-            os: linux
-            arch: x86_64
-            build-type: Release
-            cc: clang
-            clang_tidy: "False"
-            cxx: clang++
-            exceptions: "True"
-            generator: "Ninja"
-            int128: "True"
-            iostreams: "True"
-            linux-container: johnmcfarlane/cnl_ci:clang-10-libcpp
-            os-version: ubuntu-20.04
-            sanitize: "False"
-            stdlib: libc++
-            toolchain: clang-libc++.cmake
-
-          # Clang-11
-          - name: clang-11
-            compiler: clang
-            version: "11"
-            os: linux
-            arch: x86_64
-            build-type: Release
-            cc: clang
-            clang_tidy: "False"
-            cxx: clang++
-            exceptions: "True"
-            generator: "Ninja"
-            int128: "True"
-            iostreams: "True"
-            linux-container: johnmcfarlane/cnl_ci:clang-11-libcpp
             os-version: ubuntu-20.04
             sanitize: "False"
             stdlib: libc++
@@ -150,6 +52,104 @@ jobs:
             sanitize: "True"
             stdlib: libc++
             toolchain: clang-libc++.cmake
+
+          # Clang-11
+          - name: clang-11
+            compiler: clang
+            version: "11"
+            os: linux
+            arch: x86_64
+            build-type: Release
+            cc: clang
+            clang_tidy: "False"
+            cxx: clang++
+            exceptions: "True"
+            generator: "Ninja"
+            int128: "True"
+            iostreams: "True"
+            linux-container: johnmcfarlane/cnl_ci:clang-11-libcpp
+            os-version: ubuntu-20.04
+            sanitize: "False"
+            stdlib: libc++
+            toolchain: clang-libc++.cmake
+
+          # Clang-10
+          - name: clang-10
+            compiler: clang
+            version: "10"
+            os: linux
+            arch: x86_64
+            build-type: Release
+            cc: clang
+            clang_tidy: "False"
+            cxx: clang++
+            exceptions: "True"
+            generator: "Ninja"
+            int128: "True"
+            iostreams: "True"
+            linux-container: johnmcfarlane/cnl_ci:clang-10-libcpp
+            os-version: ubuntu-20.04
+            sanitize: "False"
+            stdlib: libc++
+            toolchain: clang-libc++.cmake
+
+          # GCC-10 (Contrary)
+          - name: gcc-10
+            compiler: gcc
+            version: "10"
+            os: linux
+            arch: x86_64
+            build-type: Debug
+            cc: gcc-10
+            clang_tidy: "False"
+            cxx: g++-10
+            exceptions: "False"
+            generator: "Unix Makefiles"
+            int128: "False"
+            iostreams: "False"
+            linux-container: johnmcfarlane/cnl_ci:gcc-10
+            os-version: ubuntu-20.04
+            sanitize: "True"
+            stdlib: libstdc++11
+            toolchain: gcc.cmake
+
+          # OS X Clang (latest)
+          - name: osx-clang
+            os: osx
+            compiler: clang
+            version: "13"
+            arch: x86_64
+            build-type: Debug
+            cc: "/usr/local/opt/llvm/bin/clang"
+            clang_tidy: "False"
+            cxx: "/usr/local/opt/llvm/bin/clang++"
+            exceptions: "False"
+            generator: "Unix Makefiles"
+            int128: "True"
+            iostreams: "True"
+            os-version: macos-10.15
+            sanitize: "False"
+            stdlib: libc++
+            toolchain: clang-libc++.cmake
+
+          # OS X GCC-11
+          - name: osx-gcc-11
+            os: osx
+            compiler: gcc
+            version: "11"
+            arch: x86_64
+            build-type: Release
+            cc: gcc-11
+            clang_tidy: "False"
+            cxx: g++-11
+            exceptions: "True"
+            generator: "Ninja"
+            int128: "True"
+            iostreams: "True"
+            os-version: macos-10.15
+            sanitize: "False"
+            stdlib: libstdc++11
+            toolchain: gcc.cmake
 
           # GCC-10 (for ARMv7)
           - name: armv7

--- a/include/cnl/_impl/custom_operator/homogeneous_operator_tag_base.h
+++ b/include/cnl/_impl/custom_operator/homogeneous_operator_tag_base.h
@@ -23,7 +23,7 @@ namespace cnl {
         };
 
         template<class Tag>
-        concept homogeneous_operator_tag = tag<Tag>&& std::is_base_of_v<homogeneous_operator_tag_base, Tag>;
+        concept homogeneous_operator_tag = tag<Tag> && std::is_base_of_v<homogeneous_operator_tag_base, Tag>;
 
         // 'Boring' tags make use of the generic operator system.
         // For example, when you add two `rounding_nearest_tag` numbers together,

--- a/include/cnl/_impl/custom_operator/overloads.h
+++ b/include/cnl/_impl/custom_operator/overloads.h
@@ -34,7 +34,8 @@ namespace cnl {
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CNL_DEFINE_UNARY_OPERATOR(OP, NAME) \
     template<class Operand> \
-    requires _impl::wants_generic_ops<Operand> [[nodiscard]] constexpr auto operator OP(Operand const& rhs) \
+    requires _impl::wants_generic_ops<Operand> \
+    [[nodiscard]] constexpr auto operator OP(Operand const& rhs) \
     { \
         return cnl::custom_operator<NAME, cnl::op_value<Operand>>()(rhs); \
     }
@@ -50,7 +51,8 @@ namespace cnl {
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CNL_DEFINE_BINARY_OPERATOR(OP, NAME) \
     template<cnl::arithmetic LhsOperand, cnl::arithmetic RhsOperand> \
-    requires wants_generic_ops_binary<LhsOperand, RhsOperand> [[nodiscard]] constexpr auto \
+    requires wants_generic_ops_binary<LhsOperand, RhsOperand> \
+    [[nodiscard]] constexpr auto \
     operator OP(LhsOperand const& lhs, RhsOperand const& rhs) \
     { \
         return cnl::custom_operator<NAME, cnl::op_value<LhsOperand>, cnl::op_value<RhsOperand>>{}( \
@@ -78,7 +80,8 @@ namespace cnl {
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CNL_DEFINE_SHIFT_OPERATOR(OP, NAME) \
     template<cnl::arithmetic LhsOperand, cnl::arithmetic RhsOperand> \
-    requires wants_generic_ops_binary<LhsOperand, RhsOperand> [[nodiscard]] constexpr auto \
+    requires wants_generic_ops_binary<LhsOperand, RhsOperand> \
+    [[nodiscard]] constexpr auto \
     operator OP(LhsOperand const& lhs, RhsOperand const& rhs) \
     { \
         return cnl::custom_operator<NAME, op_value<LhsOperand>, op_value<RhsOperand>>()(lhs, rhs); \
@@ -93,7 +96,8 @@ namespace cnl {
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CNL_DEFINE_COMPARISON_OPERATOR(OP, NAME) \
     template<cnl::arithmetic LhsOperand, cnl::arithmetic RhsOperand> \
-    requires wants_generic_ops_binary<LhsOperand, RhsOperand> [[nodiscard]] constexpr auto \
+    requires wants_generic_ops_binary<LhsOperand, RhsOperand> \
+    [[nodiscard]] constexpr auto \
     operator OP(LhsOperand const& lhs, RhsOperand const& rhs) \
     { \
         return cnl::custom_operator<NAME, op_value<LhsOperand>, op_value<RhsOperand>>()(lhs, rhs); \
@@ -145,7 +149,8 @@ namespace cnl {
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CNL_DEFINE_COMPOUND_ASSIGNMENT_OPERATOR(OP, NAME) \
     template<cnl::arithmetic LhsOperand, cnl::arithmetic RhsOperand> \
-    requires _impl::wants_generic_ops_binary<LhsOperand, RhsOperand> constexpr auto operator OP(LhsOperand& lhs, RhsOperand const& rhs) \
+    requires _impl::wants_generic_ops_binary<LhsOperand, RhsOperand> \
+    constexpr auto operator OP(LhsOperand& lhs, RhsOperand const& rhs) \
     { \
         return cnl::custom_operator< \
                 NAME, op_value<LhsOperand>, op_value<RhsOperand>>()(lhs, rhs); \
@@ -172,7 +177,8 @@ namespace cnl {
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CNL_DEFINE_COMPOUND_ASSIGNMENT_SHIFT_OPERATOR(OP, NAME) \
     template<cnl::arithmetic LhsOperand, cnl::arithmetic RhsOperand> \
-    requires _impl::wants_generic_ops_binary<LhsOperand, RhsOperand> constexpr auto operator OP(LhsOperand& lhs, RhsOperand const& rhs) \
+    requires _impl::wants_generic_ops_binary<LhsOperand, RhsOperand> \
+    constexpr auto operator OP(LhsOperand& lhs, RhsOperand const& rhs) \
     { \
         return cnl::custom_operator< \
                 NAME, op_value<LhsOperand>, op_value<RhsOperand>>()(lhs, rhs); \

--- a/include/cnl/_impl/duplex_integer/definition.h
+++ b/include/cnl/_impl/duplex_integer/definition.h
@@ -56,12 +56,10 @@ namespace cnl {
             constexpr duplex_integer(upper_type const& u, lower_type const& l);
 
             template<integer Number>
-            constexpr duplex_integer(Number const& n);  // NOLINT(hicpp-explicit-conversions,
-                    // google-explicit-constructor)
+            constexpr duplex_integer(Number const& n);  // NOLINT(hicpp-explicit-conversions,google-explicit-constructor)
 
             template<floating_point Number>
-            constexpr duplex_integer(Number const& n);  // NOLINT(hicpp-explicit-conversions,
-                    // google-explicit-constructor)
+            constexpr duplex_integer(Number const& n);  // NOLINT(hicpp-explicit-conversions,google-explicit-constructor)
 
             [[nodiscard]] constexpr auto upper() const -> upper_type const&
             {

--- a/include/cnl/_impl/num_traits/fixed_width_scale.h
+++ b/include/cnl/_impl/num_traits/fixed_width_scale.h
@@ -39,7 +39,8 @@ namespace cnl {
     }
 
     template<int Digits, int Radix, typename Composite>
-    requires is_composite_v<Composite> struct fixed_width_scale<
+    requires is_composite_v<Composite>
+    struct fixed_width_scale<
             Digits, Radix, Composite> {
         [[nodiscard]] constexpr auto operator()(Composite const& s) const
         {

--- a/include/cnl/_impl/num_traits/set_digits.h
+++ b/include/cnl/_impl/num_traits/set_digits.h
@@ -19,7 +19,7 @@
 namespace cnl {
     namespace _impl {
         template<typename T>
-        concept signed_integral = integral<T>&& numbers::signedness_v<T>;
+        concept signed_integral = integral<T> && numbers::signedness_v<T>;
 
         template<typename T>
         concept unsigned_integral = integral<T> && !numbers::signedness_v<T>;

--- a/include/cnl/_impl/num_traits/unwrap.h
+++ b/include/cnl/_impl/num_traits/unwrap.h
@@ -25,7 +25,8 @@ namespace cnl {
         };
 
         template<typename Number>
-        requires is_composite_v<Number> struct unwrap<Number> {
+        requires is_composite_v<Number>
+        struct unwrap<Number> {
             [[nodiscard]] constexpr auto operator()(Number const& n) const
             {
                 return unwrap<rep_of_t<Number>>{}(to_rep(n));

--- a/include/cnl/_impl/overflow/is_overflow.h
+++ b/include/cnl/_impl/overflow/is_overflow.h
@@ -325,7 +325,8 @@ namespace cnl {
         template<>
         struct is_overflow<shift_left_op, polarity::negative> {
             template<typename Lhs, typename Rhs>
-            requires numbers::signedness_v<Lhs> [[nodiscard]] constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
+            requires numbers::signedness_v<Lhs>
+            [[nodiscard]] constexpr auto operator()(Lhs const& lhs, Rhs const& rhs) const
             {
                 using traits = operator_overflow_traits<shift_left_op, Lhs, Rhs>;
                 return lhs < 0 ? rhs > 0 ? rhs < traits::positive_digits

--- a/include/cnl/_impl/overflow/is_overflow_tag.h
+++ b/include/cnl/_impl/overflow/is_overflow_tag.h
@@ -22,7 +22,8 @@ namespace cnl {
     template<class T>
     concept overflow_tag = _impl::is_overflow_tag<T>::value;
 
-    namespace _impl {
+    namespace _impl
+    {
         template<overflow_tag Tag1, overflow_tag Tag2>
         struct is_same_tag_family<Tag1, Tag2>
             : std::true_type {

--- a/include/cnl/_impl/power_value.h
+++ b/include/cnl/_impl/power_value.h
@@ -38,9 +38,7 @@ namespace cnl {
             [[nodiscard]] constexpr auto operator()() const
             {
                 using result_numeric_limits = numeric_limits<decltype(
-                        decltype(
-                                std::declval<S>()
-                                >> std::declval<constant<digits_v<S> - 1>>()){1}
+                        decltype(std::declval<S>() >> std::declval<constant<digits_v<S> - 1>>()){1}
                         << constant<Exponent>{})>;
                 static_assert(
                         !std::is_integral<S>::value || !std::is_signed<S>::value
@@ -49,9 +47,7 @@ namespace cnl {
 
                 // TODO: This expression is so ugly that it might justify
                 // a separate specialization of power for elastic_integer
-                return decltype(
-                               std::declval<S>()
-                               >> std::declval<constant<digits_v<S> - 1>>()){1}
+                return decltype(std::declval<S>() >> std::declval<constant<digits_v<S> - 1>>()){1}
                     << constant<Exponent>{};
             }
         };

--- a/include/cnl/_impl/rounding/is_rounding_tag.h
+++ b/include/cnl/_impl/rounding/is_rounding_tag.h
@@ -25,7 +25,8 @@ namespace cnl {
     template<class T>
     concept rounding_tag = _impl::is_rounding_tag<T>::value;
 
-    namespace _impl {
+    namespace _impl
+    {
         template<rounding_tag Tag1, rounding_tag Tag2>
         struct is_same_tag_family<Tag1, Tag2>
             : std::true_type {

--- a/include/cnl/_impl/wide_tag/is_wide_tag.h
+++ b/include/cnl/_impl/wide_tag/is_wide_tag.h
@@ -22,7 +22,7 @@ namespace cnl {
         inline constexpr auto is_wide_tag<wide_tag<Digits, Narrowest>> = true;
 
         template<class T>
-        concept any_wide_tag = is_tag<T>&& is_wide_tag<T>;
+        concept any_wide_tag = is_tag<T> && is_wide_tag<T>;
     }
 }
 

--- a/test/unit/scaled_int/scaled_int_common.h
+++ b/test/unit/scaled_int/scaled_int_common.h
@@ -899,9 +899,7 @@ static_assert(
 static_assert(
         identical(
                 scaled_integer<
-                        decltype(
-                                std::declval<test_int>()
-                                + std::declval<uint8>() * std::declval<test_int>()),
+                        decltype(std::declval<test_int>() + std::declval<uint8>() * std::declval<test_int>()),
                         cnl::power<0>>{12288},
                 2048 + scaled_integer<uint8, cnl::power<10>>(10240)),
         "cnl::scaled_integer addition operator test failed");

--- a/test/unit/scaled_int/scaled_int_common.h
+++ b/test/unit/scaled_int/scaled_int_common.h
@@ -27,10 +27,10 @@
 
 TEST(TOKENPASTE2(TEST_LABEL, copy_assignment), from_scaled_integer)  // NOLINT
 {
-    auto lhs = scaled_integer<int32, cnl::power<-16>>(0);
-    lhs = static_cast<scaled_integer<int32, cnl::power<-16>>>(123.456);
     auto expected = scaled_integer<int32, cnl::power<-16>>(123.456);
-    ASSERT_EQ(expected, lhs);
+    auto actual = scaled_integer<int32, cnl::power<-16>>(0);
+    actual = static_cast<scaled_integer<int32, cnl::power<-16>>>(123.456);
+    ASSERT_EQ(expected, actual);
 }
 
 TEST(TOKENPASTE2(TEST_LABEL, copy_assignment), from_floating_point)  // NOLINT

--- a/test/unit/static_number/operators.cpp
+++ b/test/unit/static_number/operators.cpp
@@ -24,7 +24,7 @@ namespace {
     {
         static_assert(cnl::static_number<1>{1}, "in-range boundary test");
         static_assert(cnl::static_number<1>{-1}, "in-range boundary test");
-        ASSERT_DEATH(cnl::static_number<1>{-2}, "negative overflow");
+        ASSERT_DEATH(cnl::static_number<1>{-2}, "negative overflow");  // NOLINT
     }
 #endif
 
@@ -93,25 +93,25 @@ namespace {
     TEST(static_number, pre_increment_overflow)  // NOLINT
     {
         auto a = cnl::static_number<4, -2>{3.0};
-        ASSERT_DEATH(++a, "positive overflow");
+        ASSERT_DEATH(++a, "positive overflow");  // NOLINT
     }
 
     TEST(static_number, pre_decrement_overflow)  // NOLINT
     {
         auto a = cnl::static_number<4, -2>{-3.0};
-        ASSERT_DEATH(--a, "negative overflow");
+        ASSERT_DEATH(--a, "negative overflow");  // NOLINT
     }
 
     TEST(static_number, post_increment_overflow)  // NOLINT
     {
         auto a = cnl::static_number<4, -2>{3.0};
-        ASSERT_DEATH(a++, "positive overflow");
+        ASSERT_DEATH(a++, "positive overflow");  // NOLINT
     }
 
     TEST(static_number, post_decrement_overflow)  // NOLINT
     {
         auto a = cnl::static_number<4, -2>{-3.0};
-        ASSERT_DEATH(a--, "negative overflow");
+        ASSERT_DEATH(a--, "negative overflow");  // NOLINT
     }
 #endif
 }


### PR DESCRIPTION
- make -head images more prominent
  - clang-head-analyse
    - uses Clang-14 pre-release
    - used to Clang-Tidy/sanitizers in Conan job
  - gcc-head
    - uses GCC-12 pre-release
  - sanitizers enabled by default in Conan jobs
- CMake jobs just use clang-13 and gcc-11
- clang-format upgraded to clang-13