### PR TITLE
Disable bogus warnings in latest GCC

### DIFF
--- a/.github/conan/profiles/linux-gcc-head
+++ b/.github/conan/profiles/linux-gcc-head
@@ -5,3 +5,4 @@ compiler.version=12
 sanitize=True
 [build_requires]
 [env]
+CONAN_CMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_DIR/gcc-head.cmake

--- a/test/toolchain/gcc-head.cmake
+++ b/test/toolchain/gcc-head.cmake
@@ -1,0 +1,6 @@
+include("${CMAKE_CURRENT_LIST_DIR}/gcc.cmake")
+
+set(
+    CNL_CXX_FLAGS
+    "${CNL_CXX_FLAGS} -Wno-array-bounds -Wno-stringop-overread"
+)


### PR DESCRIPTION
90% certain this warning is bogus. [GCC bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88443). [creduced repro](https://godbolt.org/z/h7fsqacfd)