### PR TITLE
Clamp Boost version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -35,7 +35,7 @@ class CnlConan(ConanFile):
     no_copy_source = True
     requires = [
         "benchmark/[~1.6]",
-        "boost/[~1.71]",
+        "boost/1.77.0",
         "gtest/[~1.11]",
     ]
 


### PR DESCRIPTION
- in hopes of avoiding CI job failures caused by slow JFrog REST API.
- example failure:
  - job:
    https://github.com/johnmcfarlane/cnl/runs/4427931463?check_suite_focus=true#step:7:51
  - message:
    ERROR: HTTPSConnectionPool(host='center.conan.io', port=443): Max retries exceeded with url: /v1/conans/search?q=boost%2F%2A&ignorecase=False (Caused by ReadTimeoutError("HTTPSConnectionPool(host='center.conan.io', port=443): Read timed out. (read timeout=60.0)"))
- GitHub issue:
  https://github.com/conan-io/conan-center-index/issues/950
- JFrog issue:
  https://www.jfrog.com/jira/browse/RTFACT-26310