### PR TITLE
Split break-it script in two

### DIFF
--- a/.github/break-it
+++ b/.github/break-it
@@ -7,5 +7,11 @@ ONTO="${1:-origin/main}"
 for tool in asan clang-tidy ubsan clang-format doxygen mdl shellcheck yamllint
 do
   branch="break-it_${tool}"
-  git checkout "${branch}" && git rebase --onto="${ONTO}" "${branch}"^ && git push -f
+  git checkout "${branch}" && git rebase --onto="${ONTO}" "${branch}"^
+done
+
+for tool in asan clang-tidy ubsan clang-format doxygen mdl shellcheck yamllint
+do
+  branch="break-it_${tool}"
+  git checkout "${branch}" && git push -f
 done


### PR DESCRIPTION
- perform all the refactoring first
- put all the results second
- makes resolving conflicts smoother