### PR TITLE
Remove wide-integer check from CI

### DIFF
--- a/.github/workflows/wide-integer.yml
+++ b/.github/workflows/wide-integer.yml
@@ -2,12 +2,8 @@
 name: wide-integer
 
 on:
-  pull_request:
-    branches:
-      - '**'
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   # Check for updates to wide-integer library


### PR DESCRIPTION
- Run daily to remind if update is available.
- Isn't otherwise helpful during PR process.
- Config taken from wide-integer project.