### PR TITLE
Fix incorrect use of exponent as fractional digits

### DIFF
--- a/include/cnl/_impl/scaled_integer/num_traits.h
+++ b/include/cnl/_impl/scaled_integer/num_traits.h
@@ -71,8 +71,8 @@ namespace cnl {
     // scaled_integer specializations of scaled_integer-specific templates
 
     namespace _impl {
-        template<typename Rep, int Exponent, int Radix>
-        struct fractional_digits<scaled_integer<Rep, power<Exponent, Radix>>> : std::integral_constant<int, -Exponent> {
+        template<typename Rep, int Exponent>
+        struct fractional_digits<scaled_integer<Rep, power<Exponent, 2>>> : std::integral_constant<int, -Exponent> {
         };
     }
 }

--- a/include/cnl/_impl/scaled_integer/to_chars_capacity.h
+++ b/include/cnl/_impl/scaled_integer/to_chars_capacity.h
@@ -58,8 +58,7 @@ namespace cnl::_impl {
             constexpr auto radix{Scale::radix};
 
             // This number is a little pessemistic in the case that radix != 2.
-            auto const fractional_digits =
-                    std::max(cnl::_impl::fractional_digits_v<type>, 0);
+            auto const fractional_digits = std::max(-exponent, 0);
 
             auto const sign_chars = static_cast<int>(cnl::numbers::signedness_v<type>);
             auto const num_significant_integer_bits{cnl::digits_v<type> - fractional_digits};


### PR DESCRIPTION
- Only true when Radis is binary (2)
- Add test of to_chars_static of elastic_scaled_integer