### PR TITLE
Fix clang-tidy failure in benchmark lib

### DIFF
--- a/.github/conan/profiles/linux-clang-tidy
+++ b/.github/conan/profiles/linux-clang-tidy
@@ -1,3 +1,4 @@
 include(linux-clang-14-libc++)
 [env]
-CONAN_CMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_DIR/clang-tidy.cmake
+CONAN_CMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_DIR/clang-libc++.cmake
+cnl:CONAN_CMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_DIR/clang-tidy.cmake


### PR DESCRIPTION
- Clang-Tidy shouldn't be checking dependencies