### PR TITLE
Fixed redefinition error when compiling with g++12

### DIFF
--- a/test/unit/presentations/cppcon2017.cpp
+++ b/test/unit/presentations/cppcon2017.cpp
@@ -20,7 +20,7 @@ namespace filesystem = std::filesystem;
 template<typename Rep = int, int Exponent = 0, int Radix = 2>
 using fixed_point = cnl::scaled_integer<Rep, cnl::power<Exponent, Radix>>;
 
-#if !defined(_MSC_VER) || _MSC_VER < 1932  // wg21.link/LWG3657
+#if (defined(_MSC_VER) && _MSC_VER < 1932)  || (defined(__GNUC__) && __cplusplus < 201703L) // wg21.link/LWG3657
 template<>
 struct std::hash<filesystem::path> {
     auto operator()(filesystem::path const& p) const

--- a/test/unit/presentations/cppdub2018.cpp
+++ b/test/unit/presentations/cppdub2018.cpp
@@ -22,7 +22,7 @@ using cnl::make_scaled_integer;
 using cnl::power;
 using cnl::scaled_integer;
 
-#if !defined(_MSC_VER) || _MSC_VER < 1932  // wg21.link/LWG3657
+#if (defined(_MSC_VER) && _MSC_VER < 1932)  || (defined(__GNUC__) && __cplusplus < 201703L) // wg21.link/LWG3657
 template<>
 struct std::hash<filesystem::path> {
     auto operator()(filesystem::path const& p) const


### PR DESCRIPTION
Two tests won't compile when done so with g++12 because of an old workaround added for MSVC. I've extended it to include g++ and just plucked out the __cpluscplus version string from my locally installed filesystem include file.